### PR TITLE
feat(game): strategy-first UX + warm board-game UI redesign

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,20 @@
+## Design Context
+
+### Users
+Game theory researchers and collaborators building/exploring Dark Hex strategies. Used in research workflow — needs to be functional but enjoyable. Multiple contributors.
+
+### Brand Personality
+Warm, playful, tactile — like a physical board game you want to pick up and play.
+
+### Aesthetic Direction
+- **Tone**: Board-game warmth — think Jenga, wooden tokens, felt tabletops. The 3D board already nails this with mauve tiles and soft blue sky. UI panels should feel like part of the game, not bolted-on developer tools.
+- **Anti-references**: Clinical/corporate dashboards, dark-mode developer tools, generic SaaS panels.
+- **Theme**: Light/warm — matching the existing soft blue background and mauve board palette.
+- **Typography**: Friendly and readable, not monospace/terminal.
+
+### Design Principles
+1. **Part of the game** — UI elements should feel like game pieces, scorecards, or wooden signs, not floating developer panels.
+2. **Readable at a glance** — generous sizing, clear hierarchy, no squinting at 11px text.
+3. **Warm materials** — use the existing palette (mauve, cream, soft blue) throughout; avoid cold dark panels.
+4. **Playful but functional** — delightful details that don't get in the way of research work.
+5. **Tactile affordances** — buttons and controls should look pressable, inputs should look fillable.

--- a/game/index.html
+++ b/game/index.html
@@ -4,13 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>DSaGe — Dark Hex Strategy Generator</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
       html, body {
         width: 100%; height: 100%;
-        background: #06070d;
+        background: #c2e1ff;
         overflow: hidden;
-        font-family: 'Courier New', monospace;
+        font-family: 'Nunito', -apple-system, BlinkMacSystemFont, sans-serif;
       }
       #app { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; }
       canvas { display: block; }

--- a/game/index.html
+++ b/game/index.html
@@ -11,7 +11,7 @@
       * { margin: 0; padding: 0; box-sizing: border-box; }
       html, body {
         width: 100%; height: 100%;
-        background: #b8daf5;
+        background: #c2e1ff;
         overflow: hidden;
         font-family: 'Nunito', -apple-system, BlinkMacSystemFont, sans-serif;
       }

--- a/game/index.html
+++ b/game/index.html
@@ -11,7 +11,7 @@
       * { margin: 0; padding: 0; box-sizing: border-box; }
       html, body {
         width: 100%; height: 100%;
-        background: #c2e1ff;
+        background: #b8daf5;
         overflow: hidden;
         font-family: 'Nunito', -apple-system, BlinkMacSystemFont, sans-serif;
       }

--- a/game/src/board/BoardLayout.ts
+++ b/game/src/board/BoardLayout.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three'
 import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js'
 import { HexTile3D, type TileState } from './HexTile'
-import { gridToWorld, boardCenter, HEX, PALETTE } from './IsometricHex'
+import { gridToWorld, HEX, PALETTE } from './IsometricHex'
 import { toonMat } from './ToonMaterials'
 
 // ── Edge piece neighbor offsets per edge index ────────────────────────────────
@@ -141,9 +141,6 @@ export class BoardLayout3D {
 
     // Win-condition edge pieces (chevron bands along each border)
     this._buildEdgePieces(scene)
-
-    // Cream platform base
-    this._buildPlatform(scene, rows, cols)
   }
 
   // ── Tile accessors ────────────────────────────────────────────────────────
@@ -277,33 +274,4 @@ export class BoardLayout3D {
     }
   }
 
-  // ── Platform base ─────────────────────────────────────────────────────────
-
-  private _buildPlatform(scene: THREE.Scene, rows: number, cols: number): void {
-    const [cx, , cz] = boardCenter(rows, cols)
-
-    let minX = Infinity, maxX = -Infinity
-    let minZ = Infinity, maxZ = -Infinity
-    for (let r = 0; r < rows; r++) {
-      for (let c = 0; c < cols; c++) {
-        const [x, z] = gridToWorld(r, c)
-        minX = Math.min(minX, x)
-        maxX = Math.max(maxX, x)
-        minZ = Math.min(minZ, z)
-        maxZ = Math.max(maxZ, z)
-      }
-    }
-    const pad = HEX.R * 2.2
-    const pw = (maxX - minX) + pad * 2
-    const ph = (maxZ - minZ) + pad * 2
-    const platformH = 0.5
-
-    const geo = new THREE.BoxGeometry(pw, platformH, ph, 1, 1, 1)
-    const topMat = new THREE.MeshToonMaterial({ color: PALETTE.platform })
-    const platform = new THREE.Mesh(geo, topMat)
-    platform.position.set(cx, -HEX.HEIGHT - platformH / 2 - 0.02, cz)
-    platform.castShadow = true
-    platform.receiveShadow = true
-    scene.add(platform)
-  }
 }

--- a/game/src/board/HexTile.ts
+++ b/game/src/board/HexTile.ts
@@ -96,6 +96,8 @@ export class HexTile3D {
     this._isLast = isLast
     this._hovered = false
     this._selected = false
+    // Reset tile to base height (e.g. if it was hovered/selected when stone placed)
+    this.group.userData['targetY'] = this._baseY
     this._updateColors()
     this._updateStone()
   }

--- a/game/src/board/IsometricHex.ts
+++ b/game/src/board/IsometricHex.ts
@@ -98,36 +98,36 @@ export function boardCenter(rows: number, cols: number): [number, number, number
   return [(x0 + x1) / 2, 0, (z0 + z1) / 2]
 }
 
-// ── Palette — warm board-game colours with more saturation ──────────────────
+// ── Palette — soft pastels with a bit more life ─────────────────────────────
 
 export const PALETTE = {
-  bg:          0xb8daf5,       // slightly deeper sky blue
+  bg:          0xc2e1ff,
 
-  tileTop:     0xe0a8a0,       // warmer terracotta-rose (was grayish-pink)
-  tileSide:    0xc48878,       // richer clay side
-  tileDark:    0xa05848,       // deeper terracotta shadow
+  tileTop:     0xe0b8b8,       // softer pastel rose (was grayish #d5b7b7)
+  tileSide:    0xd09a9a,       // warmer rose side
+  tileDark:    0xa86868,
 
-  hoverTop:    0xecc0b8,       // warm highlight on hover
+  hoverTop:    0xeacece,       // gentle hover lift
 
-  blackTop:    0x3a4460,       // richer navy-slate
-  blackSide:   0x2a3148,       // deeper navy side
-  blackEdge:   0x0c0e14,
+  blackTop:    0x506080,       // more saturated slate-blue
+  blackSide:   0x3c4860,
+  blackEdge:   0x0c0e11,
 
-  whiteTop:    0xf0ece4,       // warm ivory (was cold gray-blue)
-  whiteSide:   0xd8d0c4,       // warm linen side
-  whiteHi:     0x8a8070,
+  whiteTop:    0xe8e0d8,       // warm cream-white (was cold #d6dae4)
+  whiteSide:   0xd0c8be,
+  whiteHi:     0x7b86a6,
 
-  edgeBlackTop:  0x3a4460,
-  edgeBlackSide: 0x2a3148,
-  edgeWhiteTop:  0xf0ece4,
-  edgeWhiteSide: 0xd8d0c4,
+  edgeBlackTop:  0x506080,
+  edgeBlackSide: 0x3c4860,
+  edgeWhiteTop:  0xe8e0d8,
+  edgeWhiteSide: 0xd0c8be,
 
-  lastTop:     0xd49888,       // warm recent-move highlight
-  selectedTop: 0x7cc47e,       // fresh green — selected tile
-  selectedSide:0x5ca860,
+  lastTop:     0xd8a8a8,       // soft rose for last move
+  selectedTop: 0x81c784,       // soft green — selected tile in strategy mode
+  selectedSide:0x66a869,
 
-  platform:    0xfaf5ef,       // cream platform (matches UI)
-  platformEdge:0xd5c8b8,      // warm edge
+  platform:    0xffffff,
+  platformEdge:0xcccccc,
 
-  outline:     0x3a2820,       // warm dark brown outlines (was cold gray)
+  outline:     0x2a2a30,
 } as const

--- a/game/src/board/IsometricHex.ts
+++ b/game/src/board/IsometricHex.ts
@@ -98,36 +98,36 @@ export function boardCenter(rows: number, cols: number): [number, number, number
   return [(x0 + x1) / 2, 0, (z0 + z1) / 2]
 }
 
-// ── Palette — exact values from the reference SVG ───────────────────────────
+// ── Palette — warm board-game colours with more saturation ──────────────────
 
 export const PALETTE = {
-  bg:          0xc2e1ff,
+  bg:          0xb8daf5,       // slightly deeper sky blue
 
-  tileTop:     0xd5b7b7,
-  tileSide:    0xc29797,
-  tileDark:    0x995a5a,
+  tileTop:     0xe0a8a0,       // warmer terracotta-rose (was grayish-pink)
+  tileSide:    0xc48878,       // richer clay side
+  tileDark:    0xa05848,       // deeper terracotta shadow
 
-  hoverTop:    0xe0caca,
+  hoverTop:    0xecc0b8,       // warm highlight on hover
 
-  blackTop:    0x4c556b,
-  blackSide:   0x373d4d,
-  blackEdge:   0x0c0e11,
+  blackTop:    0x3a4460,       // richer navy-slate
+  blackSide:   0x2a3148,       // deeper navy side
+  blackEdge:   0x0c0e14,
 
-  whiteTop:    0xd6dae4,
-  whiteSide:   0xb8becf,
-  whiteHi:     0x7b86a6,
+  whiteTop:    0xf0ece4,       // warm ivory (was cold gray-blue)
+  whiteSide:   0xd8d0c4,       // warm linen side
+  whiteHi:     0x8a8070,
 
-  edgeBlackTop:  0x4c556b,
-  edgeBlackSide: 0x373d4d,
-  edgeWhiteTop:  0xd6dae4,
-  edgeWhiteSide: 0xb8becf,
+  edgeBlackTop:  0x3a4460,
+  edgeBlackSide: 0x2a3148,
+  edgeWhiteTop:  0xf0ece4,
+  edgeWhiteSide: 0xd8d0c4,
 
-  lastTop:     0xccaaaa,
-  selectedTop: 0x81c784,   // soft green — selected tile in strategy mode
-  selectedSide:0x66a869,
+  lastTop:     0xd49888,       // warm recent-move highlight
+  selectedTop: 0x7cc47e,       // fresh green — selected tile
+  selectedSide:0x5ca860,
 
-  platform:    0xffffff,
-  platformEdge:0xcccccc,
+  platform:    0xfaf5ef,       // cream platform (matches UI)
+  platformEdge:0xd5c8b8,      // warm edge
 
-  outline:     0x2a2a30,
+  outline:     0x3a2820,       // warm dark brown outlines (was cold gray)
 } as const

--- a/game/src/board/ToonMaterials.ts
+++ b/game/src/board/ToonMaterials.ts
@@ -4,7 +4,7 @@ import * as THREE from 'three'
 let _gradientMap: THREE.DataTexture | null = null
 export function gradientMap(): THREE.DataTexture {
   if (!_gradientMap) {
-    const colors = new Uint8Array([160, 220, 255])
+    const colors = new Uint8Array([100, 200, 255])
     _gradientMap = new THREE.DataTexture(colors, 3, 1, THREE.RedFormat)
     _gradientMap.needsUpdate = true
     _gradientMap.minFilter = THREE.NearestFilter

--- a/game/src/board/ToonMaterials.ts
+++ b/game/src/board/ToonMaterials.ts
@@ -4,7 +4,7 @@ import * as THREE from 'three'
 let _gradientMap: THREE.DataTexture | null = null
 export function gradientMap(): THREE.DataTexture {
   if (!_gradientMap) {
-    const colors = new Uint8Array([100, 200, 255])
+    const colors = new Uint8Array([160, 220, 255])
     _gradientMap = new THREE.DataTexture(colors, 3, 1, THREE.RedFormat)
     _gradientMap.needsUpdate = true
     _gradientMap.minFilter = THREE.NearestFilter

--- a/game/src/scenes/BoardScene.ts
+++ b/game/src/scenes/BoardScene.ts
@@ -364,8 +364,8 @@ export class BoardScene {
       label.textContent = prob
       label.style.cssText = `
         position: absolute; transform: translate(-50%, -50%);
-        color: #fff; font-family: 'Courier New', monospace; font-size: 14px;
-        font-weight: bold; text-shadow: 0 1px 3px rgba(0,0,0,0.7);
+        color: #fff; font-family: 'Nunito', -apple-system, sans-serif; font-size: 16px;
+        font-weight: 800; text-shadow: 0 1px 4px rgba(0,0,0,0.5);
         pointer-events: none;
       `
       this.probOverlay.appendChild(label)

--- a/game/src/scenes/BoardScene.ts
+++ b/game/src/scenes/BoardScene.ts
@@ -3,7 +3,6 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 import { BoardLayout3D } from '../board/BoardLayout'
 import { HexTile3D } from '../board/HexTile'
 import { boardCenter, PALETTE } from '../board/IsometricHex'
-import { GameEngine, type Player } from '../engine/GameEngine'
 import { InfoStateOps } from '../engine/InfoStateOps'
 import { createOutlineComposer } from '../postprocess/OutlinePostProcess'
 import { StrategyGenerator } from '../strategy/StrategyGenerator'
@@ -13,9 +12,6 @@ import { InfoPanel } from '../ui/InfoPanel'
 
 const BOARD_ROWS = 4
 const BOARD_COLS = 3
-const PLAYER_LABEL: Record<Player, string> = { 0: 'Black', 1: 'White' }
-
-type Mode = 'play' | 'strategy'
 
 /**
  * Main 3D scene: orthographic camera at isometric angle,
@@ -27,7 +23,6 @@ export class BoardScene {
   private camera: THREE.OrthographicCamera
   private controls: OrbitControls
 
-  private engine!: GameEngine
   private board!: BoardLayout3D
 
   private outlineRender!: ReturnType<typeof createOutlineComposer>
@@ -35,18 +30,11 @@ export class BoardScene {
   private raycaster = new THREE.Raycaster()
   private pointer = new THREE.Vector2()
   private hoveredTile: HexTile3D | null = null
-  private lastMoveIndex: number | null = null
 
   private clock = new THREE.Clock()
   private _rafId = 0
 
-  private statusEl!: HTMLDivElement
-  private infoEl!: HTMLDivElement
-  private hudTop!: HTMLDivElement
-  private hudBottom!: HTMLDivElement
-
   // Strategy mode
-  private mode: Mode = 'play'
   private stratGen: StrategyGenerator | null = null
   private setupPanel!: SetupPanel
   private actionPanel!: ActionPanel
@@ -110,10 +98,8 @@ export class BoardScene {
       thickness: 2,
     })
 
-    // ── HUD ───────────────────────────────────────────────────────────────
-    this._buildHud()
-
     // ── Events ────────────────────────────────────────────────────────────
+    this.container.style.position = 'relative'
     this.renderer.domElement.addEventListener('pointermove', this._onPointerMove)
     this.renderer.domElement.addEventListener('pointerdown', this._onPointerDown)
     window.addEventListener('resize', this._onResize)
@@ -121,7 +107,6 @@ export class BoardScene {
   }
 
   async init(): Promise<void> {
-    this.engine = await GameEngine.create(BOARD_ROWS, BOARD_COLS)
     this.board = new BoardLayout3D(this.scene, BOARD_ROWS, BOARD_COLS)
     this.setupPanel = new SetupPanel(this.container)
     this.actionPanel = new ActionPanel(this.container)
@@ -139,8 +124,10 @@ export class BoardScene {
     this.actionPanel.onRnd(() => this._handleStrategyAction('r'))
     this.actionPanel.onProbChange((probs) => this._syncProbOverlaysFromInputs(probs))
 
-    this._updateHud()
     this._animate()
+
+    // Go straight into strategy mode
+    this._enterStrategyMode()
   }
 
   // ── Render loop ─────────────────────────────────────────────────────────
@@ -150,7 +137,7 @@ export class BoardScene {
     const dt = this.clock.getDelta()
     this.controls.update()
     if (this.board) this.board.tickAnimations(dt)
-    if (this.mode === 'strategy') this._updateProbLabelPositions()
+    this._updateProbLabelPositions()
     this.outlineRender.render()
   }
 
@@ -217,64 +204,38 @@ export class BoardScene {
     this._updatePointer(e)
     const tile = this._raycastTile()
     if (!tile) return
+    if (!this.stratGen) return
+    if (tile.state !== 'empty') return
 
-    if (this.mode === 'strategy') {
-      if (!this.stratGen) return
-      if (tile.state !== 'empty') return
+    const now = Date.now()
+    const isDoubleClick = (now - this._lastClickTime < 400) && tile.cellIndex === this._lastClickTile
+    this._lastClickTime = now
+    this._lastClickTile = tile.cellIndex
 
-      const now = Date.now()
-      const isDoubleClick = (now - this._lastClickTime < 400) && tile.cellIndex === this._lastClickTile
-      this._lastClickTime = now
-      this._lastClickTile = tile.cellIndex
-
-      if (isDoubleClick) {
-        // Double-click: instant deterministic action
-        this._clearSelection()
-        this._handleConfirm([tile.cellIndex], [1.0])
-        return
-      }
-
-      // Toggle tile selection
-      if (this.selectedTiles.has(tile.cellIndex)) {
-        this.selectedTiles.delete(tile.cellIndex)
-        tile.setSelected(false)
-      } else {
-        this.selectedTiles.set(tile.cellIndex, 1)
-        tile.setSelected(true)
-      }
-      this._syncSelectionUI()
+    if (isDoubleClick) {
+      // Double-click: instant deterministic action
+      this._clearSelection()
+      this._handleConfirm([tile.cellIndex], [1.0])
       return
     }
 
-    // Play mode
-    if (this.engine.isTerminal) return
-    const legal = this.engine.legalActions()
-    if (!legal.includes(tile.cellIndex)) return
-
-    const result = this.engine.applyAction(tile.cellIndex)
-    this.lastMoveIndex = result.placed ? tile.cellIndex : null
-    this.board.applyBoard(this.engine.trueBoard(), this.lastMoveIndex)
-    this._updateHud()
+    // Toggle tile selection
+    if (this.selectedTiles.has(tile.cellIndex)) {
+      this.selectedTiles.delete(tile.cellIndex)
+      tile.setSelected(false)
+    } else {
+      this.selectedTiles.set(tile.cellIndex, 1)
+      tile.setSelected(true)
+    }
+    this._syncSelectionUI()
   }
 
   private _onKeyDown = (e: KeyboardEvent): void => {
-    if (this.mode === 'strategy') {
-      if (e.key === 'Escape') this._exitStrategyMode()
-      if (e.key === 'Enter' && this.selectedTiles.size > 0) {
-        const result = this.actionPanel.getActionProbs()
-        if (result) this._handleConfirm(result.actions, result.probs)
-      }
-      return
+    if (e.key === 'Escape') this._restartStrategyMode()
+    if (e.key === 'Enter' && this.selectedTiles.size > 0) {
+      const result = this.actionPanel.getActionProbs()
+      if (result) this._handleConfirm(result.actions, result.probs)
     }
-    if (e.key === 'r' || e.key === 'R') this._reset()
-    if (e.key === 's' || e.key === 'S') this._enterStrategyMode()
-  }
-
-  private async _reset(): Promise<void> {
-    this.engine = await GameEngine.create(BOARD_ROWS, BOARD_COLS)
-    this.lastMoveIndex = null
-    this.board.applyBoard(this.engine.trueBoard(), null)
-    this._updateHud()
   }
 
   // ── Strategy mode ─────────────────────────────────────────────────────────
@@ -314,31 +275,22 @@ export class BoardScene {
 
     const infoOps = await InfoStateOps.create(config.rows, config.cols)
     this.stratGen = new StrategyGenerator(infoOps, config)
-    this.mode = 'strategy'
 
-    this.hudTop.style.display = 'none'
-    this.hudBottom.style.display = 'none'
     this.actionPanel.show()
     this.infoPanel.show()
     this._updateStrategyView()
   }
 
-  private _exitStrategyMode(): void {
+  /** Escape: tear down current strategy and re-open setup panel. */
+  private _restartStrategyMode(): void {
     this._clearSelection()
-    // Clear prob overlay labels directly (in case _clearSelection skipped due to empty stratGen)
     for (const el of this.probLabels.values()) el.remove()
     this.probLabels.clear()
-    this.mode = 'play'
     this.stratGen = null
     this.actionPanel.hide()
     this.infoPanel.hide()
 
-    // Restore play-mode board and HUD
-    this.hudTop.style.display = 'flex'
-    this.hudBottom.style.display = 'flex'
-    this._rebuildBoard(BOARD_ROWS, BOARD_COLS)
-    this.board.applyBoard(this.engine.trueBoard(), this.lastMoveIndex)
-    this._updateHud()
+    this._enterStrategyMode()
   }
 
   /** Confirm selected actions with given probabilities. */
@@ -494,60 +446,4 @@ export class BoardScene {
     this.outlineRender.resize(w, h)
   }
 
-  // ── HUD ───────────────────────────────────────────────────────────────
-
-  private _buildHud(): void {
-    this.hudTop = document.createElement('div')
-    this.hudTop.style.cssText = `
-      position: absolute; top: 0; left: 0; width: 100%; pointer-events: none;
-      font-family: 'Courier New', monospace; color: #4a5568;
-      padding: 16px 24px; display: flex; flex-direction: column; gap: 4px;
-    `
-    this.container.style.position = 'relative'
-    this.container.appendChild(this.hudTop)
-
-    const title = document.createElement('div')
-    title.textContent = 'DSaGe — Dark Hex Strategy Generator'
-    title.style.cssText = 'font-size: 13px; color: #64748b;'
-    this.hudTop.appendChild(title)
-
-    this.statusEl = document.createElement('div')
-    this.statusEl.style.cssText = 'font-size: 15px; margin-top: 4px;'
-    this.hudTop.appendChild(this.statusEl)
-
-    this.hudBottom = document.createElement('div')
-    this.hudBottom.style.cssText = `
-      position: absolute; bottom: 0; left: 0; width: 100%;
-      padding: 10px 24px; font-size: 11px; color: #64748b;
-      display: flex; justify-content: space-between; pointer-events: none;
-    `
-    this.container.appendChild(this.hudBottom)
-
-    this.infoEl = document.createElement('div')
-    this.hudBottom.appendChild(this.infoEl)
-
-    const legend = document.createElement('div')
-    legend.innerHTML =
-      '<span style="color:#5c6bc0">● Black</span> top↔bottom &nbsp; ' +
-      '<span style="color:#ef5350">● White</span> left↔right &nbsp; ' +
-      '<span style="color:#94a3b8">[R] restart &nbsp; [S] strategy</span>'
-    this.hudBottom.appendChild(legend)
-  }
-
-  private _updateHud(): void {
-    if (this.engine.isTerminal) {
-      const w = this.engine.winner!
-      const color = w === 0 ? '#5c6bc0' : '#ef5350'
-      this.statusEl.innerHTML = `<span style="color:${color}">${PLAYER_LABEL[w]} wins!</span>`
-      this.infoEl.textContent = ''
-    } else {
-      const p = this.engine.currentPlayer
-      const color = p === 0 ? '#5c6bc0' : '#ef5350'
-      const n = this.engine.legalActions().length
-      this.statusEl.innerHTML =
-        `<span style="color:${color}">${PLAYER_LABEL[p]}'s turn</span>` +
-        ` <span style="color:#94a3b8; font-size:13px">(${n} moves)</span>`
-      this.infoEl.textContent = `info: ${this.engine.infoStateString(p)}`
-    }
-  }
 }

--- a/game/src/scenes/BoardScene.ts
+++ b/game/src/scenes/BoardScene.ts
@@ -232,7 +232,8 @@ export class BoardScene {
   }
 
   private _onKeyDown = (e: KeyboardEvent): void => {
-    if (e.key === 'Escape' && !this._setupOpen) this._restartStrategyMode()
+    if (this._setupOpen) return
+    if (e.key === 'Escape') this._restartStrategyMode()
     if (e.key === 'Enter' && this.selectedTiles.size > 0) {
       const result = this.actionPanel.getActionProbs()
       if (result) this._handleConfirm(result.actions, result.probs)
@@ -442,6 +443,7 @@ export class BoardScene {
       remaining,
       player: this.stratGen.player,
       isCollision: this.stratGen.lastCollisionIndex !== null,
+      perfectRecall: this.stratGen.perfectRecall,
     })
   }
 

--- a/game/src/scenes/BoardScene.ts
+++ b/game/src/scenes/BoardScene.ts
@@ -155,11 +155,11 @@ export class BoardScene {
   // ── Lights ──────────────────────────────────────────────────────────────
 
   private _setupLights(cx: number, cz: number): void {
-    // Warm ambient — enough to see side faces but let directional create shading
-    this.scene.add(new THREE.AmbientLight(0xfff8f0, 0.85))
+    // Strong neutral ambient — dominates so colors render close to their hex values
+    this.scene.add(new THREE.AmbientLight(0xffffff, 1.2))
 
-    // Stronger directional — drives toon shading steps and warm shadows
-    const key = new THREE.DirectionalLight(0xfff4e8, 0.7)
+    // Gentle directional — just enough to create soft shadows and slight shading
+    const key = new THREE.DirectionalLight(0xffffff, 0.4)
     key.position.set(cx + 6, 14, cz - 4)
     key.target.position.set(cx, 0, cz)
     key.castShadow = true

--- a/game/src/scenes/BoardScene.ts
+++ b/game/src/scenes/BoardScene.ts
@@ -155,11 +155,11 @@ export class BoardScene {
   // ── Lights ──────────────────────────────────────────────────────────────
 
   private _setupLights(cx: number, cz: number): void {
-    // Strong neutral ambient — dominates so colors render close to their hex values
-    this.scene.add(new THREE.AmbientLight(0xffffff, 1.2))
+    // Warm ambient — enough to see side faces but let directional create shading
+    this.scene.add(new THREE.AmbientLight(0xfff8f0, 0.85))
 
-    // Gentle directional — just enough to create soft shadows and slight shading
-    const key = new THREE.DirectionalLight(0xffffff, 0.4)
+    // Stronger directional — drives toon shading steps and warm shadows
+    const key = new THREE.DirectionalLight(0xfff4e8, 0.7)
     key.position.set(cx + 6, 14, cz - 4)
     key.target.position.set(cx, 0, cz)
     key.castShadow = true

--- a/game/src/scenes/BoardScene.ts
+++ b/game/src/scenes/BoardScene.ts
@@ -35,6 +35,7 @@ export class BoardScene {
   private _rafId = 0
 
   // Strategy mode
+  private _setupOpen = false
   private stratGen: StrategyGenerator | null = null
   private setupPanel!: SetupPanel
   private actionPanel!: ActionPanel
@@ -231,7 +232,7 @@ export class BoardScene {
   }
 
   private _onKeyDown = (e: KeyboardEvent): void => {
-    if (e.key === 'Escape') this._restartStrategyMode()
+    if (e.key === 'Escape' && !this._setupOpen) this._restartStrategyMode()
     if (e.key === 'Enter' && this.selectedTiles.size > 0) {
       const result = this.actionPanel.getActionProbs()
       if (result) this._handleConfirm(result.actions, result.probs)
@@ -266,8 +267,10 @@ export class BoardScene {
     this.controls.update()
   }
 
-  private async _enterStrategyMode(): Promise<void> {
-    const config = await this.setupPanel.show()
+  private async _enterStrategyMode(cancellable = false): Promise<void> {
+    this._setupOpen = true
+    const config = await this.setupPanel.show(cancellable)
+    this._setupOpen = false
     if (!config) return
 
     // Rebuild board for the requested dimensions
@@ -281,16 +284,40 @@ export class BoardScene {
     this._updateStrategyView()
   }
 
-  /** Escape: tear down current strategy and re-open setup panel. */
-  private _restartStrategyMode(): void {
+  /** Escape: show setup panel; cancel returns to current strategy. */
+  private async _restartStrategyMode(): Promise<void> {
+    const hadStrategy = this.stratGen !== null
+
+    // Hide panels while setup is showing
+    this.actionPanel.hide()
+    this.infoPanel.hide()
+
+    this._setupOpen = true
+    const config = await this.setupPanel.show(hadStrategy)
+    this._setupOpen = false
+    if (!config) {
+      // User cancelled — restore previous strategy view if one exists
+      if (hadStrategy) {
+        this.actionPanel.show()
+        this.infoPanel.show()
+      }
+      return
+    }
+
+    // Tear down old strategy and start fresh
     this._clearSelection()
     for (const el of this.probLabels.values()) el.remove()
     this.probLabels.clear()
     this.stratGen = null
-    this.actionPanel.hide()
-    this.infoPanel.hide()
 
-    this._enterStrategyMode()
+    this._rebuildBoard(config.rows, config.cols)
+
+    const infoOps = await InfoStateOps.create(config.rows, config.cols)
+    this.stratGen = new StrategyGenerator(infoOps, config)
+
+    this.actionPanel.show()
+    this.infoPanel.show()
+    this._updateStrategyView()
   }
 
   /** Confirm selected actions with given probabilities. */

--- a/game/src/ui/ActionPanel.ts
+++ b/game/src/ui/ActionPanel.ts
@@ -1,8 +1,18 @@
-/** Format 1/n so that n copies sum to exactly 1.00 within display tolerance.
- *  Uses enough decimal places (up to 6) to avoid rounding rejection. */
+// ── Shared style tokens ────────────────────────────────────────────────────
+const FONT = "'Nunito', -apple-system, BlinkMacSystemFont, sans-serif"
+const CREAM = '#faf5ef'
+const MAUVE_DARK = '#995a5a'
+const MAUVE_LIGHT = '#e8d5d5'
+const TEXT = '#4a3535'
+const TEXT_MUTED = '#8a7070'
+const GREEN = '#5a9a5e'
+const GREEN_LIGHT = '#e8f5e9'
+const GREEN_BORDER = '#b5d8b7'
+const SHADOW = '0 -4px 16px rgba(100, 60, 60, 0.10)'
+
+/** Format 1/n so that n copies sum to exactly 1.00 within display tolerance. */
 function eqProb(n: number): string {
   const raw = 1 / n
-  // Try increasing precision until n * rounded == 1 within tolerance
   for (let d = 2; d <= 6; d++) {
     const s = raw.toFixed(d)
     const sum = parseFloat(s) * n
@@ -12,8 +22,8 @@ function eqProb(n: number): string {
 }
 
 /**
- * Thin bottom toolbar for strategy mode.
- * Shows selected actions with editable probabilities + control buttons.
+ * Bottom toolbar for strategy mode.
+ * Warm parchment card with action pills, probability editing, and controls.
  */
 export class ActionPanel {
   private container: HTMLDivElement
@@ -30,55 +40,68 @@ export class ActionPanel {
   constructor(parent: HTMLElement) {
     this.container = document.createElement('div')
     this.container.style.cssText = `
-      display: none; position: fixed; bottom: 0; left: 0; right: 0;
-      background: rgba(26,26,46,0.92); border-top: 1px solid #4a4a6a;
-      padding: 8px 16px; z-index: 50;
-      font-family: 'Courier New', monospace; color: #e0e0e0; font-size: 13px;
-      align-items: center; gap: 8px;
+      display: none; position: fixed; bottom: 12px; left: 12px; right: 12px;
+      background: ${CREAM}; border: 2px solid ${MAUVE_LIGHT}; border-radius: 12px;
+      padding: 14px 18px; z-index: 50;
+      font-family: ${FONT}; color: ${TEXT}; font-size: 15px;
+      box-shadow: ${SHADOW};
+      align-items: center; gap: 12px;
     `
 
-    // Selection area (shows selected actions with prob inputs)
+    // ── Selection area ──────────────────────────────────────────────────
     this.selectionEl = document.createElement('div')
-    this.selectionEl.style.cssText = 'flex: 1; display: flex; gap: 6px; align-items: center; flex-wrap: wrap; min-height: 32px;'
+    this.selectionEl.style.cssText = `
+      flex: 1; display: flex; gap: 8px; align-items: center;
+      flex-wrap: wrap; min-height: 40px;
+    `
     this.container.appendChild(this.selectionEl)
 
-    // Sum indicator
+    // ── Sum indicator ───────────────────────────────────────────────────
     this.sumEl = document.createElement('span')
-    this.sumEl.style.cssText = 'font-size: 12px; min-width: 70px; text-align: right; margin-right: 4px;'
+    this.sumEl.style.cssText = `
+      font-size: 14px; font-weight: 700; min-width: 90px;
+      text-align: right; margin-right: 4px;
+    `
     this.container.appendChild(this.sumEl)
 
-    // Buttons
+    // ── Buttons ─────────────────────────────────────────────────────────
     const buttonsEl = document.createElement('div')
-    buttonsEl.style.cssText = 'display: flex; gap: 4px; align-items: center;'
+    buttonsEl.style.cssText = 'display: flex; gap: 6px; align-items: center;'
 
-    const btnBase = `
-      padding: 6px 10px; border: none; border-radius: 4px; cursor: pointer;
-      font-family: inherit; font-size: 12px;
-    `
-
-    const equalBtn = this.makeBtn('=', `${btnBase} background: #4a6a5c; color: #fff;`)
-    equalBtn.title = 'Set all equal'
-    equalBtn.addEventListener('click', () => { this.setAllEqual(); this.onProbInput() })
+    const equalBtn = this._makeBtn('Equal', CREAM, TEXT, `border: 2px solid ${MAUVE_LIGHT}`)
+    equalBtn.title = 'Set all probabilities equal'
+    equalBtn.addEventListener('click', () => { this.setAllEqual(); this._onProbInput() })
     buttonsEl.appendChild(equalBtn)
 
-    this.confirmBtn = this.makeBtn('Confirm', `${btnBase} background: #5c6bc0; color: #fff; font-weight: bold;`)
-    this.confirmBtn.addEventListener('click', () => this.fireConfirm())
+    this.confirmBtn = this._makeBtn('Confirm', MAUVE_DARK, '#fff', `
+      border: none; font-weight: 800;
+      box-shadow: 0 2px 0 #7a4040;
+    `)
+    this.confirmBtn.addEventListener('click', () => this._fireConfirm())
+    this.confirmBtn.addEventListener('mousedown', () => {
+      this.confirmBtn.style.transform = 'translateY(1px)'
+      this.confirmBtn.style.boxShadow = '0 1px 0 #7a4040'
+    })
+    this.confirmBtn.addEventListener('mouseup', () => {
+      this.confirmBtn.style.transform = ''
+      this.confirmBtn.style.boxShadow = '0 2px 0 #7a4040'
+    })
     buttonsEl.appendChild(this.confirmBtn)
 
     const sep = document.createElement('div')
-    sep.style.cssText = 'width: 1px; height: 20px; background: #4a4a6a; margin: 0 4px;'
+    sep.style.cssText = `width: 2px; height: 24px; background: ${MAUVE_LIGHT}; margin: 0 4px; border-radius: 1px;`
     buttonsEl.appendChild(sep)
 
-    const rndBtn = this.makeBtn('Rnd', `${btnBase} background: #6a5c4a; color: #fff;`)
-    rndBtn.title = 'Random action'
+    const rndBtn = this._makeBtn('Random', CREAM, TEXT, `border: 2px solid ${MAUVE_LIGHT}`)
+    rndBtn.title = 'Assign a random action'
     rndBtn.addEventListener('click', () => this.rndCallbacks.forEach(cb => cb()))
     buttonsEl.appendChild(rndBtn)
 
-    const undoBtn = this.makeBtn('Undo', `${btnBase} background: #4a4a6a; color: #e0e0e0;`)
+    const undoBtn = this._makeBtn('Undo', CREAM, TEXT, `border: 2px solid ${MAUVE_LIGHT}`)
     undoBtn.addEventListener('click', () => this.undoCallbacks.forEach(cb => cb()))
     buttonsEl.appendChild(undoBtn)
 
-    const restartBtn = this.makeBtn('Rst', `${btnBase} background: #6a4a4a; color: #e0e0e0;`)
+    const restartBtn = this._makeBtn('Restart', '#fff0e0', '#c75000', `border: 2px solid #ffd5a0`)
     restartBtn.addEventListener('click', () => this.restartCallbacks.forEach(cb => cb()))
     buttonsEl.appendChild(restartBtn)
 
@@ -94,10 +117,11 @@ export class ActionPanel {
     if (selected.size === 0) {
       const hint = document.createElement('span')
       hint.textContent = 'Click tiles to select actions'
-      hint.style.color = '#666'
+      hint.style.cssText = `color: ${TEXT_MUTED}; font-size: 15px; font-weight: 600; font-style: italic;`
       this.selectionEl.appendChild(hint)
       this.sumEl.textContent = ''
-      this.confirmBtn.style.opacity = '0.4'
+      this.confirmBtn.style.opacity = '0.35'
+      this.confirmBtn.style.pointerEvents = 'none'
       return
     }
 
@@ -108,32 +132,35 @@ export class ActionPanel {
 
       const pill = document.createElement('div')
       pill.style.cssText = `
-        display: flex; align-items: center; gap: 3px;
-        background: #2a3a2a; border: 1px solid #4a6a4a; border-radius: 4px;
-        padding: 2px 6px;
+        display: flex; align-items: center; gap: 6px;
+        background: ${GREEN_LIGHT}; border: 2px solid ${GREEN_BORDER};
+        border-radius: 8px; padding: 4px 10px;
       `
 
       const label = document.createElement('span')
       label.textContent = name
-      label.style.cssText = 'color: #81c784; font-weight: bold; font-size: 13px;'
+      label.style.cssText = `color: ${GREEN}; font-weight: 800; font-size: 15px;`
       pill.appendChild(label)
 
       const input = document.createElement('input')
       input.type = 'text'
       input.value = eqProb(selected.size)
       input.style.cssText = `
-        width: 40px; background: #1a2a1a; color: #e0e0e0; border: 1px solid #4a6a4a;
-        padding: 2px 4px; font-family: inherit; font-size: 12px; border-radius: 3px;
-        text-align: center;
+        width: 56px; background: #fff; color: ${TEXT}; border: 2px solid ${GREEN_BORDER};
+        padding: 4px 6px; font-family: ${FONT}; font-size: 15px; font-weight: 700;
+        border-radius: 6px; text-align: center; outline: none;
+        transition: border-color 0.15s;
       `
-      input.addEventListener('input', () => this.onProbInput())
+      input.addEventListener('focus', () => { input.style.borderColor = GREEN })
+      input.addEventListener('blur', () => { input.style.borderColor = GREEN_BORDER })
+      input.addEventListener('input', () => this._onProbInput())
       pill.appendChild(input)
       this.probInputs.set(cellIdx, input)
 
       this.selectionEl.appendChild(pill)
     }
 
-    this.onProbInput()
+    this._onProbInput()
   }
 
   /** Set all probability inputs to equal values. */
@@ -147,26 +174,28 @@ export class ActionPanel {
   }
 
   /** Compute sum, update indicator, enable/disable confirm, notify board overlays. */
-  private onProbInput(): void {
-    const sum = this.computeSum()
+  private _onProbInput(): void {
+    const sum = this._computeSum()
     const valid = Math.abs(sum - 1) <= 0.01
     const remaining = 1 - sum
 
     if (this.probInputs.size === 0) {
       this.sumEl.textContent = ''
-      this.confirmBtn.style.opacity = '0.4'
+      this.confirmBtn.style.opacity = '0.35'
+      this.confirmBtn.style.pointerEvents = 'none'
       return
     }
 
-    // Sum indicator with color
     if (valid) {
-      this.sumEl.innerHTML = `<span style="color:#81c784;">&#10003; = 1.00</span>`
+      this.sumEl.innerHTML = `<span style="color: ${GREEN}; font-size: 15px;">&#10003; = 1.00</span>`
       this.confirmBtn.style.opacity = '1'
+      this.confirmBtn.style.pointerEvents = ''
     } else {
-      const color = sum > 1 ? '#ef9a9a' : '#ffcc80'
+      const color = sum > 1 ? '#c75000' : '#b8860b'
       const sign = remaining >= 0 ? '+' : ''
-      this.sumEl.innerHTML = `<span style="color:${color};">&Sigma; ${sum.toFixed(2)} (${sign}${remaining.toFixed(2)})</span>`
-      this.confirmBtn.style.opacity = '0.4'
+      this.sumEl.innerHTML = `<span style="color: ${color};">&Sigma; ${sum.toFixed(2)} <span style="font-size:13px;">(${sign}${remaining.toFixed(2)})</span></span>`
+      this.confirmBtn.style.opacity = '0.35'
+      this.confirmBtn.style.pointerEvents = 'none'
     }
 
     // Notify listeners (for board overlay sync)
@@ -178,7 +207,7 @@ export class ActionPanel {
     this.probChangeCallbacks.forEach(cb => cb(probMap))
   }
 
-  private computeSum(): number {
+  private _computeSum(): number {
     let sum = 0
     for (const input of this.probInputs.values()) {
       const p = parseFloat(input.value)
@@ -199,50 +228,37 @@ export class ActionPanel {
     }
     const sum = probs.reduce((a, b) => a + b, 0)
     if (Math.abs(sum - 1) > 0.01) return null
-    // Normalize to exactly 1
     for (let i = 0; i < probs.length; i++) probs[i] /= sum
     return { actions, probs }
   }
 
-  onConfirm(cb: (actions: number[], probs: number[]) => void): void {
-    this.confirmCallbacks.push(cb)
-  }
+  onConfirm(cb: (actions: number[], probs: number[]) => void): void { this.confirmCallbacks.push(cb) }
+  onUndo(cb: () => void): void { this.undoCallbacks.push(cb) }
+  onRestart(cb: () => void): void { this.restartCallbacks.push(cb) }
+  onRnd(cb: () => void): void { this.rndCallbacks.push(cb) }
+  onProbChange(cb: (probs: Map<number, number>) => void): void { this.probChangeCallbacks.push(cb) }
 
-  onUndo(cb: () => void): void {
-    this.undoCallbacks.push(cb)
-  }
+  show(): void { this.container.style.display = 'flex' }
+  hide(): void { this.container.style.display = 'none' }
 
-  onRestart(cb: () => void): void {
-    this.restartCallbacks.push(cb)
-  }
-
-  onRnd(cb: () => void): void {
-    this.rndCallbacks.push(cb)
-  }
-
-  /** Called when probability inputs change — use to sync board overlays. */
-  onProbChange(cb: (probs: Map<number, number>) => void): void {
-    this.probChangeCallbacks.push(cb)
-  }
-
-  show(): void {
-    this.container.style.display = 'flex'
-  }
-
-  hide(): void {
-    this.container.style.display = 'none'
-  }
-
-  private fireConfirm(): void {
+  private _fireConfirm(): void {
     const result = this.getActionProbs()
-    if (!result) return // blocked: sum != 1
+    if (!result) return
     this.confirmCallbacks.forEach(cb => cb(result.actions, result.probs))
   }
 
-  private makeBtn(text: string, style: string): HTMLButtonElement {
+  private _makeBtn(text: string, bg: string, fg: string, extra = ''): HTMLButtonElement {
     const btn = document.createElement('button')
     btn.textContent = text
-    btn.style.cssText = style
+    btn.style.cssText = `
+      padding: 8px 14px; border-radius: 8px; cursor: pointer;
+      font-family: ${FONT}; font-size: 14px; font-weight: 700;
+      background: ${bg}; color: ${fg};
+      transition: filter 0.12s, transform 0.1s;
+      ${extra}
+    `
+    btn.addEventListener('mouseover', () => { btn.style.filter = 'brightness(0.94)' })
+    btn.addEventListener('mouseout', () => { btn.style.filter = ''; btn.style.transform = '' })
     return btn
   }
 }

--- a/game/src/ui/InfoPanel.ts
+++ b/game/src/ui/InfoPanel.ts
@@ -89,7 +89,7 @@ export class InfoPanel {
     isCollision: boolean
   }): void {
     const playerName = state.player === 0 ? 'Black' : 'White'
-    const playerColor = state.player === 0 ? '#3a4460' : MAUVE_DARK
+    const playerColor = state.player === 0 ? '#506080' : MAUVE_DARK
     this.titleEl.textContent = `Strategy: ${playerName}`
     this.titleEl.style.color = playerColor
 

--- a/game/src/ui/InfoPanel.ts
+++ b/game/src/ui/InfoPanel.ts
@@ -1,66 +1,82 @@
+// ── Shared style tokens ────────────────────────────────────────────────────
+const FONT = "'Nunito', -apple-system, BlinkMacSystemFont, sans-serif"
+const CREAM = '#faf5ef'
+const MAUVE_DARK = '#995a5a'
+const MAUVE_LIGHT = '#e8d5d5'
+const TEXT = '#4a3535'
+const TEXT_MUTED = '#8a7070'
+const SHADOW = '0 4px 16px rgba(100, 60, 60, 0.12)'
+
 /**
- * Top panel showing strategy generator progress and current info state.
+ * Compact top bar showing strategy progress.
+ * Title + progress bar + collision badge in a single row.
  */
 export class InfoPanel {
   private container: HTMLDivElement
   private titleEl: HTMLSpanElement
-  private progressEl: HTMLDivElement
   private barEl: HTMLDivElement
-  private stateEl: HTMLPreElement
+  private barLabel: HTMLSpanElement
   private collisionEl: HTMLSpanElement
 
   constructor(parent: HTMLElement) {
     this.container = document.createElement('div')
     this.container.style.cssText = `
-      display: none; position: fixed; top: 0; left: 0; right: 0;
-      background: rgba(26,26,46,0.92); border-bottom: 1px solid #4a4a6a;
-      padding: 10px 16px; z-index: 50;
-      font-family: 'Courier New', monospace; color: #e0e0e0; font-size: 13px;
+      display: none; position: fixed; top: 12px; left: 12px; right: 12px;
+      background: ${CREAM}; border: 2px solid ${MAUVE_LIGHT}; border-radius: 12px;
+      padding: 12px 20px; z-index: 50;
+      font-family: ${FONT}; color: ${TEXT};
+      box-shadow: ${SHADOW};
+      align-items: center; gap: 16px;
     `
 
-    // Title row
-    const titleRow = document.createElement('div')
-    titleRow.style.cssText = 'display: flex; align-items: center; gap: 12px; margin-bottom: 6px;'
-
+    // ── Title ──────────────────────────────────────────────────────────
     this.titleEl = document.createElement('span')
-    this.titleEl.style.fontWeight = 'bold'
-    titleRow.appendChild(this.titleEl)
+    this.titleEl.style.cssText = 'font-weight: 800; font-size: 16px; white-space: nowrap;'
+    this.container.appendChild(this.titleEl)
 
+    // ── Collision badge ────────────────────────────────────────────────
     this.collisionEl = document.createElement('span')
-    this.collisionEl.style.cssText = 'color: #ef9a9a; display: none;'
-    this.collisionEl.textContent = '⚡ Collision'
-    titleRow.appendChild(this.collisionEl)
+    this.collisionEl.style.cssText = `
+      display: none; font-size: 13px; font-weight: 700;
+      color: #c75000; background: #fff0e0; padding: 3px 10px;
+      border-radius: 6px; border: 1px solid #ffd5a0; white-space: nowrap;
+    `
+    this.collisionEl.textContent = 'Collision'
+    this.container.appendChild(this.collisionEl)
 
-    const exitHint = document.createElement('span')
-    exitHint.style.cssText = 'margin-left: auto; color: #666; font-size: 11px;'
-    exitHint.textContent = '[Esc] exit'
-    titleRow.appendChild(exitHint)
-
-    this.container.appendChild(titleRow)
-
-    // Progress bar
-    this.progressEl = document.createElement('div')
-    this.progressEl.style.cssText = 'margin-bottom: 6px; display: flex; align-items: center; gap: 8px;'
-
+    // ── Progress bar ──────────────────────────────────────────────────
     const barBg = document.createElement('div')
-    barBg.style.cssText = 'flex: 1; height: 6px; background: #2a2a40; border-radius: 3px; overflow: hidden;'
+    barBg.style.cssText = `
+      flex: 1; height: 10px; background: ${MAUVE_LIGHT};
+      border-radius: 5px; overflow: hidden; min-width: 80px;
+    `
 
     this.barEl = document.createElement('div')
-    this.barEl.style.cssText = 'height: 100%; background: #5c6bc0; border-radius: 3px; transition: width 0.2s;'
+    this.barEl.style.cssText = `
+      height: 100%; background: ${MAUVE_DARK};
+      border-radius: 5px; transition: width 0.3s ease-out;
+    `
     this.barEl.style.width = '0%'
     barBg.appendChild(this.barEl)
+    this.container.appendChild(barBg)
 
-    this.progressEl.appendChild(barBg)
-    this.container.appendChild(this.progressEl)
-
-    // Current info state display
-    this.stateEl = document.createElement('pre')
-    this.stateEl.style.cssText = `
-      margin: 0; padding: 6px 8px; background: #2a2a40; border-radius: 4px;
-      font-size: 12px; overflow-x: auto; white-space: pre; color: #b8becf;
-      max-height: 60px;
+    // ── Progress label ─────────────────────────────────────────────────
+    this.barLabel = document.createElement('span')
+    this.barLabel.style.cssText = `
+      white-space: nowrap; font-size: 13px; font-weight: 700;
+      color: ${TEXT_MUTED};
     `
-    this.container.appendChild(this.stateEl)
+    this.container.appendChild(this.barLabel)
+
+    // ── Esc hint ───────────────────────────────────────────────────────
+    const exitHint = document.createElement('span')
+    exitHint.style.cssText = `
+      color: ${TEXT_MUTED}; font-size: 12px; font-weight: 600;
+      background: #fff; padding: 3px 10px; border-radius: 6px;
+      border: 1px solid ${MAUVE_LIGHT}; white-space: nowrap;
+    `
+    exitHint.textContent = 'Esc = restart'
+    this.container.appendChild(exitHint)
 
     parent.appendChild(this.container)
   }
@@ -73,26 +89,20 @@ export class InfoPanel {
     isCollision: boolean
   }): void {
     const playerName = state.player === 0 ? 'Black' : 'White'
-    const playerColor = state.player === 0 ? '#4c556b' : '#d6dae4'
+    const playerColor = state.player === 0 ? '#4c556b' : MAUVE_DARK
     this.titleEl.textContent = `Strategy: ${playerName}`
     this.titleEl.style.color = playerColor
 
     const total = state.assigned + state.remaining
     const pct = total > 0 ? (state.assigned / total) * 100 : 0
     this.barEl.style.width = `${pct}%`
-    this.progressEl.querySelector('span')?.remove()
-    const label = document.createElement('span')
-    label.style.cssText = 'white-space: nowrap; font-size: 11px; color: #888;'
-    label.textContent = `${state.assigned} / ${total} info states`
-    this.progressEl.appendChild(label)
-
-    this.stateEl.textContent = state.infoState
+    this.barLabel.textContent = `${state.assigned} / ${total}`
 
     this.collisionEl.style.display = state.isCollision ? 'inline' : 'none'
   }
 
   show(): void {
-    this.container.style.display = 'block'
+    this.container.style.display = 'flex'
   }
 
   hide(): void {

--- a/game/src/ui/InfoPanel.ts
+++ b/game/src/ui/InfoPanel.ts
@@ -17,6 +17,7 @@ export class InfoPanel {
   private barEl: HTMLDivElement
   private barLabel: HTMLSpanElement
   private collisionEl: HTMLSpanElement
+  private historyEl: HTMLDivElement
 
   constructor(parent: HTMLElement) {
     this.container = document.createElement('div')
@@ -26,7 +27,7 @@ export class InfoPanel {
       padding: 12px 20px; z-index: 50;
       font-family: ${FONT}; color: ${TEXT};
       box-shadow: ${SHADOW};
-      align-items: center; gap: 16px;
+      align-items: center; gap: 16px; flex-wrap: wrap;
     `
 
     // ── Title ──────────────────────────────────────────────────────────
@@ -78,6 +79,16 @@ export class InfoPanel {
     exitHint.textContent = 'Esc = restart'
     this.container.appendChild(exitHint)
 
+    // ── History line (perfect recall only) ─────────────────────────────
+    this.historyEl = document.createElement('div')
+    this.historyEl.style.cssText = `
+      display: none; width: 100%;
+      font-size: 13px; font-weight: 600; color: ${TEXT_MUTED};
+      padding-top: 6px; border-top: 1px solid ${MAUVE_LIGHT};
+      margin-top: 2px; overflow-x: auto; white-space: nowrap;
+    `
+    this.container.appendChild(this.historyEl)
+
     parent.appendChild(this.container)
   }
 
@@ -87,6 +98,7 @@ export class InfoPanel {
     remaining: number
     player: number
     isCollision: boolean
+    perfectRecall: boolean
   }): void {
     const playerName = state.player === 0 ? 'Black' : 'White'
     const playerColor = state.player === 0 ? '#506080' : MAUVE_DARK
@@ -99,6 +111,21 @@ export class InfoPanel {
     this.barLabel.textContent = `${state.assigned} / ${total}`
 
     this.collisionEl.style.display = state.isCollision ? 'inline' : 'none'
+
+    // Show action history for perfect recall (third line of info state string)
+    if (state.perfectRecall) {
+      const lines = state.infoState.split('\n')
+      const historyLine = lines.length >= 3 ? lines[2].trim() : ''
+      if (historyLine) {
+        this.historyEl.textContent = `History: ${historyLine}`
+        this.historyEl.style.display = 'block'
+      } else {
+        this.historyEl.textContent = 'History: (start)'
+        this.historyEl.style.display = 'block'
+      }
+    } else {
+      this.historyEl.style.display = 'none'
+    }
   }
 
   show(): void {

--- a/game/src/ui/InfoPanel.ts
+++ b/game/src/ui/InfoPanel.ts
@@ -89,7 +89,7 @@ export class InfoPanel {
     isCollision: boolean
   }): void {
     const playerName = state.player === 0 ? 'Black' : 'White'
-    const playerColor = state.player === 0 ? '#4c556b' : MAUVE_DARK
+    const playerColor = state.player === 0 ? '#3a4460' : MAUVE_DARK
     this.titleEl.textContent = `Strategy: ${playerName}`
     this.titleEl.style.color = playerColor
 

--- a/game/src/ui/SetupPanel.ts
+++ b/game/src/ui/SetupPanel.ts
@@ -17,6 +17,7 @@ const RADIUS = '14px'
  */
 export class SetupPanel {
   private overlay: HTMLDivElement
+  private cancelBtn: HTMLButtonElement
   private resolve: ((config: StrategyConfig | null) => void) | null = null
 
   constructor(parent: HTMLElement) {
@@ -160,7 +161,8 @@ export class SetupPanel {
 
     // ── Button interactions ──────────────────────────────────────────────
     const startBtn = panel.querySelector('#sg-start') as HTMLButtonElement
-    const cancelBtn = panel.querySelector('#sg-cancel') as HTMLButtonElement
+    this.cancelBtn = panel.querySelector('#sg-cancel') as HTMLButtonElement
+    const cancelBtn = this.cancelBtn
 
     startBtn.addEventListener('mousedown', () => {
       startBtn.style.transform = 'translateY(2px)'
@@ -183,7 +185,8 @@ export class SetupPanel {
     cancelBtn.addEventListener('click', () => this._cancel())
   }
 
-  show(): Promise<StrategyConfig | null> {
+  show(cancellable = false): Promise<StrategyConfig | null> {
+    this.cancelBtn.style.display = cancellable ? '' : 'none'
     this.overlay.style.display = 'flex'
     return new Promise((resolve) => { this.resolve = resolve })
   }

--- a/game/src/ui/SetupPanel.ts
+++ b/game/src/ui/SetupPanel.ts
@@ -82,7 +82,7 @@ export class SetupPanel {
             font-size: 15px; font-weight: 700; transition: all 0.15s;
             background: ${TEXT}; color: #fff; border: 2px solid ${TEXT};
           ">
-            <span style="width: 14px; height: 14px; border-radius: 50%; background: #4c556b; display: inline-block; border: 2px solid #373d4d;"></span>
+            <span style="width: 14px; height: 14px; border-radius: 50%; background: #3a4460; display: inline-block; border: 2px solid #2a3148;"></span>
             <input type="radio" name="sg-player" value="0" checked style="display: none;">
             Black
           </label>
@@ -92,7 +92,7 @@ export class SetupPanel {
             font-size: 15px; font-weight: 700; transition: all 0.15s;
             background: #fff; color: ${TEXT}; border: 2px solid ${MAUVE_LIGHT};
           ">
-            <span style="width: 14px; height: 14px; border-radius: 50%; background: #d6dae4; display: inline-block; border: 2px solid #b8becf;"></span>
+            <span style="width: 14px; height: 14px; border-radius: 50%; background: #f0ece4; display: inline-block; border: 2px solid #d8d0c4;"></span>
             <input type="radio" name="sg-player" value="1" style="display: none;">
             White
           </label>

--- a/game/src/ui/SetupPanel.ts
+++ b/game/src/ui/SetupPanel.ts
@@ -1,80 +1,204 @@
 import type { StrategyConfig } from '../strategy/types'
 
+// ── Shared style tokens ────────────────────────────────────────────────────
+const FONT = "'Nunito', -apple-system, BlinkMacSystemFont, sans-serif"
+const CREAM = '#faf5ef'
+const MAUVE = '#c29797'
+const MAUVE_DARK = '#995a5a'
+const MAUVE_LIGHT = '#e8d5d5'
+const TEXT = '#4a3535'
+const TEXT_MUTED = '#8a7070'
+const SHADOW = '0 8px 32px rgba(100, 60, 60, 0.18), 0 2px 8px rgba(100, 60, 60, 0.10)'
+const RADIUS = '14px'
+
 /**
  * Setup panel for configuring a new strategy generation session.
- * Shows a modal overlay with board size, player, and perfect-recall options.
+ * Warm board-game styled modal with visual controls.
  */
 export class SetupPanel {
-  private container: HTMLDivElement
-  private resolve: ((config: StrategyConfig) => void) | null = null
+  private overlay: HTMLDivElement
+  private resolve: ((config: StrategyConfig | null) => void) | null = null
 
   constructor(parent: HTMLElement) {
-    this.container = document.createElement('div')
-    this.container.style.cssText = `
+    this.overlay = document.createElement('div')
+    this.overlay.style.cssText = `
       display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%;
-      background: rgba(0,0,0,0.7); z-index: 100;
-      font-family: 'Courier New', monospace; color: #e0e0e0;
-      align-items: center; justify-content: center;
+      background: rgba(180, 160, 140, 0.45); backdrop-filter: blur(4px);
+      z-index: 100; align-items: center; justify-content: center;
     `
 
     const panel = document.createElement('div')
     panel.style.cssText = `
-      background: #1a1a2e; border: 2px solid #4a4a6a; border-radius: 8px;
-      padding: 24px; min-width: 280px;
+      background: ${CREAM}; border-radius: ${RADIUS}; padding: 32px 36px;
+      min-width: 340px; max-width: 400px;
+      box-shadow: ${SHADOW}; border: 2px solid ${MAUVE_LIGHT};
+      font-family: ${FONT}; color: ${TEXT};
     `
     panel.innerHTML = `
-      <h2 style="margin:0 0 16px; color:#b8becf; font-size:16px;">Strategy Generator</h2>
-      <label style="display:block; margin-bottom:8px;">
-        Rows: <input id="sg-rows" type="number" min="1" max="5" value="2"
-          style="width:48px; background:#2a2a40; color:#e0e0e0; border:1px solid #4a4a6a; padding:4px; font-family:inherit;">
-      </label>
-      <label style="display:block; margin-bottom:8px;">
-        Cols: <input id="sg-cols" type="number" min="1" max="5" value="2"
-          style="width:48px; background:#2a2a40; color:#e0e0e0; border:1px solid #4a4a6a; padding:4px; font-family:inherit;">
-      </label>
-      <div style="margin-bottom:8px;">
-        Player:
-        <label style="margin-left:8px;"><input type="radio" name="sg-player" value="0" checked> Black</label>
-        <label style="margin-left:8px;"><input type="radio" name="sg-player" value="1"> White</label>
+      <h2 style="margin: 0 0 6px; color: ${MAUVE_DARK}; font-size: 22px; font-weight: 800; letter-spacing: -0.3px;">
+        New Strategy
+      </h2>
+      <p style="margin: 0 0 24px; color: ${TEXT_MUTED}; font-size: 14px; font-weight: 400;">
+        Configure the board and choose a player to build a strategy for.
+      </p>
+
+      <div style="display: flex; gap: 16px; margin-bottom: 20px;">
+        <div style="flex: 1;">
+          <label style="display: block; font-size: 13px; font-weight: 700; color: ${TEXT_MUTED}; margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.5px;">
+            Rows
+          </label>
+          <input id="sg-rows" type="number" min="1" max="5" value="2" style="
+            width: 100%; padding: 10px 14px; font-size: 18px; font-weight: 700;
+            font-family: ${FONT}; color: ${TEXT};
+            background: #fff; border: 2px solid ${MAUVE_LIGHT}; border-radius: 10px;
+            text-align: center; outline: none; transition: border-color 0.15s;
+          " onfocus="this.style.borderColor='${MAUVE}'" onblur="this.style.borderColor='${MAUVE_LIGHT}'">
+        </div>
+        <div style="display: flex; align-items: flex-end; padding-bottom: 10px; color: ${TEXT_MUTED}; font-size: 20px; font-weight: 700;">
+          &times;
+        </div>
+        <div style="flex: 1;">
+          <label style="display: block; font-size: 13px; font-weight: 700; color: ${TEXT_MUTED}; margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.5px;">
+            Cols
+          </label>
+          <input id="sg-cols" type="number" min="1" max="5" value="2" style="
+            width: 100%; padding: 10px 14px; font-size: 18px; font-weight: 700;
+            font-family: ${FONT}; color: ${TEXT};
+            background: #fff; border: 2px solid ${MAUVE_LIGHT}; border-radius: 10px;
+            text-align: center; outline: none; transition: border-color 0.15s;
+          " onfocus="this.style.borderColor='${MAUVE}'" onblur="this.style.borderColor='${MAUVE_LIGHT}'">
+        </div>
       </div>
-      <label style="display:block; margin-bottom:16px;">
-        <input type="checkbox" id="sg-recall"> Perfect Recall
+
+      <div style="margin-bottom: 20px;">
+        <label style="display: block; font-size: 13px; font-weight: 700; color: ${TEXT_MUTED}; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.5px;">
+          Player
+        </label>
+        <div id="sg-player-group" style="display: flex; gap: 10px;">
+          <label id="sg-player-black" style="
+            flex: 1; display: flex; align-items: center; justify-content: center; gap: 8px;
+            padding: 10px 16px; border-radius: 10px; cursor: pointer;
+            font-size: 15px; font-weight: 700; transition: all 0.15s;
+            background: ${TEXT}; color: #fff; border: 2px solid ${TEXT};
+          ">
+            <span style="width: 14px; height: 14px; border-radius: 50%; background: #4c556b; display: inline-block; border: 2px solid #373d4d;"></span>
+            <input type="radio" name="sg-player" value="0" checked style="display: none;">
+            Black
+          </label>
+          <label id="sg-player-white" style="
+            flex: 1; display: flex; align-items: center; justify-content: center; gap: 8px;
+            padding: 10px 16px; border-radius: 10px; cursor: pointer;
+            font-size: 15px; font-weight: 700; transition: all 0.15s;
+            background: #fff; color: ${TEXT}; border: 2px solid ${MAUVE_LIGHT};
+          ">
+            <span style="width: 14px; height: 14px; border-radius: 50%; background: #d6dae4; display: inline-block; border: 2px solid #b8becf;"></span>
+            <input type="radio" name="sg-player" value="1" style="display: none;">
+            White
+          </label>
+        </div>
+      </div>
+
+      <label style="
+        display: flex; align-items: center; gap: 10px; margin-bottom: 28px;
+        cursor: pointer; font-size: 15px; color: ${TEXT}; font-weight: 600;
+      ">
+        <input type="checkbox" id="sg-recall" style="
+          width: 20px; height: 20px; accent-color: ${MAUVE_DARK}; cursor: pointer;
+        ">
+        Perfect Recall
       </label>
-      <div style="display:flex; gap:8px;">
-        <button id="sg-start" style="flex:1; padding:8px; background:#5c6bc0; color:#fff; border:none; border-radius:4px; cursor:pointer; font-family:inherit; font-size:13px;">
-          Start
+
+      <div style="display: flex; gap: 10px;">
+        <button id="sg-start" style="
+          flex: 2; padding: 12px 20px; font-size: 16px; font-weight: 800;
+          font-family: ${FONT}; color: #fff; background: ${MAUVE_DARK};
+          border: none; border-radius: 10px; cursor: pointer;
+          transition: background 0.15s, transform 0.1s;
+          box-shadow: 0 3px 0 #7a4040, 0 4px 12px rgba(100, 60, 60, 0.2);
+        ">
+          Start Building
         </button>
-        <button id="sg-cancel" style="flex:1; padding:8px; background:#4a4a6a; color:#e0e0e0; border:none; border-radius:4px; cursor:pointer; font-family:inherit; font-size:13px;">
+        <button id="sg-cancel" style="
+          flex: 1; padding: 12px 16px; font-size: 15px; font-weight: 700;
+          font-family: ${FONT}; color: ${TEXT_MUTED}; background: #fff;
+          border: 2px solid ${MAUVE_LIGHT}; border-radius: 10px; cursor: pointer;
+          transition: background 0.15s;
+        ">
           Cancel
         </button>
       </div>
     `
-    this.container.appendChild(panel)
-    parent.appendChild(this.container)
+    this.overlay.appendChild(panel)
+    parent.appendChild(this.overlay)
 
-    panel.querySelector('#sg-start')!.addEventListener('click', () => this.submit())
-    panel.querySelector('#sg-cancel')!.addEventListener('click', () => this.cancel())
+    // ── Player toggle logic ─────────────────────────────────────────────
+    const blackLabel = panel.querySelector('#sg-player-black') as HTMLLabelElement
+    const whiteLabel = panel.querySelector('#sg-player-white') as HTMLLabelElement
+    const blackRadio = blackLabel.querySelector('input') as HTMLInputElement
+    const whiteRadio = whiteLabel.querySelector('input') as HTMLInputElement
+
+    const updatePlayerStyles = () => {
+      if (blackRadio.checked) {
+        blackLabel.style.background = TEXT
+        blackLabel.style.color = '#fff'
+        blackLabel.style.borderColor = TEXT
+        whiteLabel.style.background = '#fff'
+        whiteLabel.style.color = TEXT
+        whiteLabel.style.borderColor = MAUVE_LIGHT
+      } else {
+        whiteLabel.style.background = TEXT
+        whiteLabel.style.color = '#fff'
+        whiteLabel.style.borderColor = TEXT
+        blackLabel.style.background = '#fff'
+        blackLabel.style.color = TEXT
+        blackLabel.style.borderColor = MAUVE_LIGHT
+      }
+    }
+
+    blackLabel.addEventListener('click', () => { blackRadio.checked = true; updatePlayerStyles() })
+    whiteLabel.addEventListener('click', () => { whiteRadio.checked = true; updatePlayerStyles() })
+
+    // ── Button interactions ──────────────────────────────────────────────
+    const startBtn = panel.querySelector('#sg-start') as HTMLButtonElement
+    const cancelBtn = panel.querySelector('#sg-cancel') as HTMLButtonElement
+
+    startBtn.addEventListener('mousedown', () => {
+      startBtn.style.transform = 'translateY(2px)'
+      startBtn.style.boxShadow = `0 1px 0 #7a4040, 0 2px 6px rgba(100, 60, 60, 0.2)`
+    })
+    startBtn.addEventListener('mouseup', () => {
+      startBtn.style.transform = ''
+      startBtn.style.boxShadow = `0 3px 0 #7a4040, 0 4px 12px rgba(100, 60, 60, 0.2)`
+    })
+    startBtn.addEventListener('mouseover', () => { startBtn.style.background = '#a84848' })
+    startBtn.addEventListener('mouseout', () => {
+      startBtn.style.background = MAUVE_DARK
+      startBtn.style.transform = ''
+      startBtn.style.boxShadow = `0 3px 0 #7a4040, 0 4px 12px rgba(100, 60, 60, 0.2)`
+    })
+    cancelBtn.addEventListener('mouseover', () => { cancelBtn.style.background = MAUVE_LIGHT })
+    cancelBtn.addEventListener('mouseout', () => { cancelBtn.style.background = '#fff' })
+
+    startBtn.addEventListener('click', () => this._submit())
+    cancelBtn.addEventListener('click', () => this._cancel())
   }
 
-  /** Show the setup panel. Resolves with config when Start is clicked. */
-  show(): Promise<StrategyConfig> {
-    this.container.style.display = 'flex'
-    return new Promise((resolve) => {
-      this.resolve = resolve
-    })
+  show(): Promise<StrategyConfig | null> {
+    this.overlay.style.display = 'flex'
+    return new Promise((resolve) => { this.resolve = resolve })
   }
 
   hide(): void {
-    this.container.style.display = 'none'
+    this.overlay.style.display = 'none'
     this.resolve = null
   }
 
-  private submit(): void {
-    const rows = parseInt((this.container.querySelector('#sg-rows') as HTMLInputElement).value, 10)
-    const cols = parseInt((this.container.querySelector('#sg-cols') as HTMLInputElement).value, 10)
-    const playerRadio = this.container.querySelector('input[name="sg-player"]:checked') as HTMLInputElement
+  private _submit(): void {
+    const rows = parseInt((this.overlay.querySelector('#sg-rows') as HTMLInputElement).value, 10)
+    const cols = parseInt((this.overlay.querySelector('#sg-cols') as HTMLInputElement).value, 10)
+    const playerRadio = this.overlay.querySelector('input[name="sg-player"]:checked') as HTMLInputElement
     const player = parseInt(playerRadio.value, 10)
-    const perfectRecall = (this.container.querySelector('#sg-recall') as HTMLInputElement).checked
+    const perfectRecall = (this.overlay.querySelector('#sg-recall') as HTMLInputElement).checked
 
     if (rows < 1 || cols < 1 || rows > 5 || cols > 5) return
 
@@ -83,7 +207,9 @@ export class SetupPanel {
     resolve?.({ rows, cols, player, perfectRecall })
   }
 
-  private cancel(): void {
+  private _cancel(): void {
+    const resolve = this.resolve
     this.hide()
+    resolve?.(null)
   }
 }

--- a/game/src/ui/SetupPanel.ts
+++ b/game/src/ui/SetupPanel.ts
@@ -82,7 +82,7 @@ export class SetupPanel {
             font-size: 15px; font-weight: 700; transition: all 0.15s;
             background: ${TEXT}; color: #fff; border: 2px solid ${TEXT};
           ">
-            <span style="width: 14px; height: 14px; border-radius: 50%; background: #3a4460; display: inline-block; border: 2px solid #2a3148;"></span>
+            <span style="width: 14px; height: 14px; border-radius: 50%; background: #506080; display: inline-block; border: 2px solid #3c4860;"></span>
             <input type="radio" name="sg-player" value="0" checked style="display: none;">
             Black
           </label>
@@ -92,7 +92,7 @@ export class SetupPanel {
             font-size: 15px; font-weight: 700; transition: all 0.15s;
             background: #fff; color: ${TEXT}; border: 2px solid ${MAUVE_LIGHT};
           ">
-            <span style="width: 14px; height: 14px; border-radius: 50%; background: #f0ece4; display: inline-block; border: 2px solid #d8d0c4;"></span>
+            <span style="width: 14px; height: 14px; border-radius: 50%; background: #e8e0d8; display: inline-block; border: 2px solid #d0c8be;"></span>
             <input type="radio" name="sg-player" value="1" style="display: none;">
             White
           </label>


### PR DESCRIPTION
## Summary

- **Strategy-first**: App launches directly into strategy mode setup — removed play mode entirely
- **UI redesign**: All panels (Setup, Info, Action) rewritten with warm cream/mauve theme matching the 3D board aesthetic, Nunito font, larger sizing, full button labels, tactile press effects
- **Setup panel UX**: Cancel hidden on first launch (prevents blank screen), shown on Escape restart
- **InfoPanel**: Compact single-row bar; removed redundant info state text display (board already shows it)
- **Pastel palette**: Tiles rosier, stones more saturated, warm cream whites
- **Platform removed**: Board floats on sky background for a cleaner look
- **Tile fix**: Stones no longer stay raised from hover state after placement

## Test plan
- [ ] App opens directly to setup panel (no play mode)
- [ ] First launch: no Cancel button — must click Start
- [ ] Escape during strategy: setup panel with Cancel, Cancel returns to current strategy
- [ ] Tiles return to base height after stone placement
- [ ] All button labels readable: Confirm, Undo, Restart, Random, Equal
- [ ] Probability validation shows green checkmark / amber warning at readable size
- [ ] Board palette is warm pastel, no grey platform underneath