### PR TITLE
feat(game): animations + synthesized sounds for DSaGe

### DIFF
--- a/game/src/audio/SoundEngine.ts
+++ b/game/src/audio/SoundEngine.ts
@@ -139,6 +139,68 @@ export function playPlace(): void {
   osc.stop(now + 0.13)
 }
 
+// ── Stone vanish (soft upward whoosh) ──────────────────────────────────────
+
+/**
+ * Airy, breathy "pff" — stone dissolving and floating away.
+ * Rising pitch with filtered noise gives an upward, evaporating quality.
+ */
+export function playVanish(): void {
+  const c = ctx()
+  if (c.state !== 'running') return
+  const now = c.currentTime
+
+  const master = c.createGain()
+  master.gain.setValueAtTime(0.08, now)
+  master.connect(c.destination)
+
+  // ── Breathy whoosh — highpass noise that fades in then out ──────────
+  const dur = 0.18
+  const noiseLen = Math.ceil(c.sampleRate * dur)
+  const noiseBuf = c.createBuffer(1, noiseLen, c.sampleRate)
+  const noiseData = noiseBuf.getChannelData(0)
+  for (let i = 0; i < noiseLen; i++) {
+    // Bell envelope — fades in then out
+    const env = Math.sin((i / noiseLen) * Math.PI)
+    noiseData[i] = (Math.random() * 2 - 1) * env
+  }
+
+  const noise = c.createBufferSource()
+  noise.buffer = noiseBuf
+
+  // Highpass that rises — gives the "upward" sensation
+  const filter = c.createBiquadFilter()
+  filter.type = 'highpass'
+  filter.frequency.setValueAtTime(400, now)
+  filter.frequency.exponentialRampToValueAtTime(2000, now + dur)
+  filter.Q.setValueAtTime(0.7, now)
+
+  const noiseGain = c.createGain()
+  noiseGain.gain.setValueAtTime(1.0, now)
+  noiseGain.gain.exponentialRampToValueAtTime(0.001, now + dur)
+
+  noise.connect(filter)
+  filter.connect(noiseGain)
+  noiseGain.connect(master)
+  noise.start(now)
+  noise.stop(now + dur)
+
+  // ── Soft rising tone — like air escaping ───────────────────────────
+  const osc = c.createOscillator()
+  osc.type = 'sine'
+  osc.frequency.setValueAtTime(200, now)
+  osc.frequency.exponentialRampToValueAtTime(500, now + 0.12)
+
+  const oscGain = c.createGain()
+  oscGain.gain.setValueAtTime(0.3, now)
+  oscGain.gain.exponentialRampToValueAtTime(0.001, now + 0.14)
+
+  osc.connect(oscGain)
+  oscGain.connect(master)
+  osc.start(now)
+  osc.stop(now + 0.15)
+}
+
 // ── Stone drop landing (clack on impact) ───────────────────────────────────
 
 /**

--- a/game/src/audio/SoundEngine.ts
+++ b/game/src/audio/SoundEngine.ts
@@ -1,0 +1,316 @@
+/**
+ * Synthesized board-game sounds using the Web Audio API.
+ * No external files — all sounds are generated programmatically.
+ *
+ * AudioContext is created lazily on first user interaction
+ * (browsers require a user gesture to start audio).
+ */
+
+let _ctx: AudioContext | null = null
+
+function ctx(): AudioContext {
+  if (!_ctx) _ctx = new AudioContext()
+  return _ctx
+}
+
+/** Resume AudioContext after a user gesture (call from first click/key). */
+export function ensureAudioReady(): void {
+  const c = ctx()
+  if (c.state === 'suspended') c.resume()
+}
+
+// ── Wooden thock (tile hover) ──────────────────────────────────────────────
+
+/**
+ * Short, punchy wooden "thock" — like placing a tile on a board.
+ * Built from a filtered noise burst + a low sine knock.
+ */
+export function playThock(): void {
+  const c = ctx()
+  if (c.state !== 'running') return
+  const now = c.currentTime
+
+  const master = c.createGain()
+  master.gain.setValueAtTime(0.13, now)
+  master.connect(c.destination)
+
+  // ── Noise burst — warm, round, less clicky ─────────────────────────
+  const noiseDur = 0.05
+  const noiseLen = Math.ceil(c.sampleRate * noiseDur)
+  const noiseBuffer = c.createBuffer(1, noiseLen, c.sampleRate)
+  const noiseData = noiseBuffer.getChannelData(0)
+  for (let i = 0; i < noiseLen; i++) {
+    // Smooth fade-out envelope (quadratic) for rounder tail
+    const env = (1 - i / noiseLen) ** 2
+    noiseData[i] = (Math.random() * 2 - 1) * env
+  }
+
+  const noise = c.createBufferSource()
+  noise.buffer = noiseBuffer
+
+  // Lower bandpass with higher Q — more "hollow wood" resonance
+  const filter = c.createBiquadFilter()
+  filter.type = 'bandpass'
+  filter.frequency.setValueAtTime(500, now)
+  filter.Q.setValueAtTime(5, now)
+
+  const noiseGain = c.createGain()
+  noiseGain.gain.setValueAtTime(0.7, now)
+  noiseGain.gain.exponentialRampToValueAtTime(0.001, now + noiseDur)
+
+  noise.connect(filter)
+  filter.connect(noiseGain)
+  noiseGain.connect(master)
+  noise.start(now)
+  noise.stop(now + noiseDur)
+
+  // ── Warm sine body — gentle pitch drop gives it "weight" ───────────
+  const osc = c.createOscillator()
+  osc.type = 'sine'
+  osc.frequency.setValueAtTime(120, now)
+  osc.frequency.exponentialRampToValueAtTime(70, now + 0.07)
+
+  const oscGain = c.createGain()
+  oscGain.gain.setValueAtTime(0.8, now)
+  oscGain.gain.exponentialRampToValueAtTime(0.001, now + 0.08)
+
+  osc.connect(oscGain)
+  oscGain.connect(master)
+  osc.start(now)
+  osc.stop(now + 0.09)
+}
+
+// ── Stone place (heavier thock for clicks) ─────────────────────────────────
+
+/**
+ * Deeper, more resonant knock — for placing a stone or confirming an action.
+ */
+export function playPlace(): void {
+  const c = ctx()
+  if (c.state !== 'running') return
+  const now = c.currentTime
+
+  const master = c.createGain()
+  master.gain.setValueAtTime(0.16, now)
+  master.connect(c.destination)
+
+  // ── Warm noise body — rounder, longer resonance ────────────────────
+  const noiseDur = 0.07
+  const noiseLen = Math.ceil(c.sampleRate * noiseDur)
+  const noiseBuffer = c.createBuffer(1, noiseLen, c.sampleRate)
+  const noiseData = noiseBuffer.getChannelData(0)
+  for (let i = 0; i < noiseLen; i++) {
+    const env = (1 - i / noiseLen) ** 2
+    noiseData[i] = (Math.random() * 2 - 1) * env
+  }
+
+  const noise = c.createBufferSource()
+  noise.buffer = noiseBuffer
+
+  // Lower, more resonant — like a thick wooden block
+  const filter = c.createBiquadFilter()
+  filter.type = 'bandpass'
+  filter.frequency.setValueAtTime(380, now)
+  filter.Q.setValueAtTime(6, now)
+
+  const noiseGain = c.createGain()
+  noiseGain.gain.setValueAtTime(0.6, now)
+  noiseGain.gain.exponentialRampToValueAtTime(0.001, now + noiseDur)
+
+  noise.connect(filter)
+  filter.connect(noiseGain)
+  noiseGain.connect(master)
+  noise.start(now)
+  noise.stop(now + noiseDur)
+
+  // ── Deep sine with slow decay — satisfying thump ───────────────────
+  const osc = c.createOscillator()
+  osc.type = 'sine'
+  osc.frequency.setValueAtTime(95, now)
+  osc.frequency.exponentialRampToValueAtTime(50, now + 0.10)
+
+  const oscGain = c.createGain()
+  oscGain.gain.setValueAtTime(0.9, now)
+  oscGain.gain.exponentialRampToValueAtTime(0.001, now + 0.12)
+
+  osc.connect(oscGain)
+  oscGain.connect(master)
+  osc.start(now)
+  osc.stop(now + 0.13)
+}
+
+// ── Stone drop landing (clack on impact) ───────────────────────────────────
+
+/**
+ * Satisfying "clack" — stone landing on the board after a drop.
+ * Sharper attack than the hover thock, with a resonant wooden tail.
+ */
+export function playDrop(): void {
+  const c = ctx()
+  if (c.state !== 'running') return
+  const now = c.currentTime
+
+  const master = c.createGain()
+  master.gain.setValueAtTime(0.18, now)
+  master.connect(c.destination)
+
+  // ── Sharp attack — short bright noise burst ────────────────────────
+  const attackDur = 0.02
+  const attackLen = Math.ceil(c.sampleRate * attackDur)
+  const attackBuf = c.createBuffer(1, attackLen, c.sampleRate)
+  const attackData = attackBuf.getChannelData(0)
+  for (let i = 0; i < attackLen; i++) {
+    attackData[i] = (Math.random() * 2 - 1) * (1 - i / attackLen)
+  }
+
+  const attack = c.createBufferSource()
+  attack.buffer = attackBuf
+
+  const hiFilter = c.createBiquadFilter()
+  hiFilter.type = 'bandpass'
+  hiFilter.frequency.setValueAtTime(1200, now)
+  hiFilter.Q.setValueAtTime(2, now)
+
+  const attackGain = c.createGain()
+  attackGain.gain.setValueAtTime(0.6, now)
+  attackGain.gain.exponentialRampToValueAtTime(0.001, now + attackDur)
+
+  attack.connect(hiFilter)
+  hiFilter.connect(attackGain)
+  attackGain.connect(master)
+  attack.start(now)
+  attack.stop(now + attackDur)
+
+  // ── Resonant body — lower, longer, wooden ring ─────────────────────
+  const bodyDur = 0.08
+  const bodyLen = Math.ceil(c.sampleRate * bodyDur)
+  const bodyBuf = c.createBuffer(1, bodyLen, c.sampleRate)
+  const bodyData = bodyBuf.getChannelData(0)
+  for (let i = 0; i < bodyLen; i++) {
+    const env = (1 - i / bodyLen) ** 2
+    bodyData[i] = (Math.random() * 2 - 1) * env
+  }
+
+  const body = c.createBufferSource()
+  body.buffer = bodyBuf
+
+  const loFilter = c.createBiquadFilter()
+  loFilter.type = 'bandpass'
+  loFilter.frequency.setValueAtTime(400, now)
+  loFilter.Q.setValueAtTime(6, now)
+
+  const bodyGain = c.createGain()
+  bodyGain.gain.setValueAtTime(0.8, now)
+  bodyGain.gain.exponentialRampToValueAtTime(0.001, now + bodyDur)
+
+  body.connect(loFilter)
+  loFilter.connect(bodyGain)
+  bodyGain.connect(master)
+  body.start(now)
+  body.stop(now + bodyDur)
+
+  // ── Deep thump — impact weight ─────────────────────────────────────
+  const osc = c.createOscillator()
+  osc.type = 'sine'
+  osc.frequency.setValueAtTime(100, now)
+  osc.frequency.exponentialRampToValueAtTime(45, now + 0.10)
+
+  const oscGain = c.createGain()
+  oscGain.gain.setValueAtTime(1.0, now)
+  oscGain.gain.exponentialRampToValueAtTime(0.001, now + 0.12)
+
+  osc.connect(oscGain)
+  oscGain.connect(master)
+  osc.start(now)
+  osc.stop(now + 0.13)
+}
+
+// ── Stone reveal (rise from below) ─────────────────────────────────────────
+
+/**
+ * Soft, muffled emergence — stone rising from beneath the tile.
+ * Quieter and more muted than the drop, with a "sliding" quality.
+ */
+export function playReveal(): void {
+  const c = ctx()
+  if (c.state !== 'running') return
+  const now = c.currentTime
+
+  const master = c.createGain()
+  master.gain.setValueAtTime(0.09, now)
+  master.connect(c.destination)
+
+  // Soft filtered noise — like something sliding into place
+  const noiseDur = 0.10
+  const noiseLen = Math.ceil(c.sampleRate * noiseDur)
+  const noiseBuffer = c.createBuffer(1, noiseLen, c.sampleRate)
+  const noiseData = noiseBuffer.getChannelData(0)
+  for (let i = 0; i < noiseLen; i++) {
+    const env = Math.sin((i / noiseLen) * Math.PI) // bell-shaped: fade in then out
+    noiseData[i] = (Math.random() * 2 - 1) * env
+  }
+
+  const noise = c.createBufferSource()
+  noise.buffer = noiseBuffer
+
+  // Low-pass — muffled, underground feel
+  const filter = c.createBiquadFilter()
+  filter.type = 'lowpass'
+  filter.frequency.setValueAtTime(300, now)
+  filter.frequency.linearRampToValueAtTime(600, now + noiseDur)
+  filter.Q.setValueAtTime(1, now)
+
+  const noiseGain = c.createGain()
+  noiseGain.gain.setValueAtTime(0.8, now)
+  noiseGain.gain.exponentialRampToValueAtTime(0.001, now + noiseDur)
+
+  noise.connect(filter)
+  filter.connect(noiseGain)
+  noiseGain.connect(master)
+  noise.start(now)
+  noise.stop(now + noiseDur)
+
+  // Gentle rising tone
+  const osc = c.createOscillator()
+  osc.type = 'sine'
+  osc.frequency.setValueAtTime(60, now)
+  osc.frequency.linearRampToValueAtTime(90, now + 0.08)
+
+  const oscGain = c.createGain()
+  oscGain.gain.setValueAtTime(0.5, now)
+  oscGain.gain.exponentialRampToValueAtTime(0.001, now + 0.10)
+
+  osc.connect(oscGain)
+  oscGain.connect(master)
+  osc.start(now)
+  osc.stop(now + 0.11)
+}
+
+// ── Collision (short buzz) ─────────────────────────────────────────────────
+
+/**
+ * Quick buzzy tap — collision feedback (stone already there).
+ */
+export function playCollision(): void {
+  const c = ctx()
+  if (c.state !== 'running') return
+  const now = c.currentTime
+
+  const master = c.createGain()
+  master.gain.setValueAtTime(0.10, now)
+  master.connect(c.destination)
+
+  const osc = c.createOscillator()
+  osc.type = 'square'
+  osc.frequency.setValueAtTime(220, now)
+  osc.frequency.exponentialRampToValueAtTime(110, now + 0.08)
+
+  const oscGain = c.createGain()
+  oscGain.gain.setValueAtTime(0.5, now)
+  oscGain.gain.exponentialRampToValueAtTime(0.001, now + 0.08)
+
+  osc.connect(oscGain)
+  oscGain.connect(master)
+  osc.start(now)
+  osc.stop(now + 0.08)
+}

--- a/game/src/board/BoardLayout.ts
+++ b/game/src/board/BoardLayout.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
 import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js'
-import { HexTile3D, type TileState } from './HexTile'
+import { HexTile3D, type TileState, type StoneAnim } from './HexTile'
 import { gridToWorld, HEX, PALETTE } from './IsometricHex'
 import { toonMat } from './ToonMaterials'
 
@@ -177,13 +177,19 @@ export class BoardLayout3D {
    * Render from an imperfect-information view array (strategy mode).
    * Same format as applyBoard but with optional collision highlight.
    */
-  applyView(view: Int8Array, collisionIndex: number | null = null): void {
+  applyView(
+    view: Int8Array,
+    collisionIndex: number | null = null,
+    defaultAnim: StoneAnim = 'rise',
+    dropOverrides?: Set<number>,
+  ): void {
     for (let r = 0; r < this.rows; r++) {
       for (let c = 0; c < this.cols; c++) {
         const idx = r * this.cols + c
         const cell = view[idx]
         const state: TileState = cell === 1 ? 'black' : cell === 2 ? 'white' : 'empty'
-        this.tiles[r][c].setState(state, false)
+        const anim = dropOverrides?.has(idx) ? 'drop' as StoneAnim : defaultAnim
+        this.tiles[r][c].setState(state, false, anim)
         if (idx === collisionIndex) {
           this.tiles[r][c].flashCollision()
         }

--- a/game/src/board/BoardLayout.ts
+++ b/game/src/board/BoardLayout.ts
@@ -183,15 +183,51 @@ export class BoardLayout3D {
     defaultAnim: StoneAnim = 'rise',
     dropOverrides?: Set<number>,
   ): void {
+    // First pass: collect tiles that are losing their stone (occupied → empty)
+    const vanishing: HexTile3D[] = []
     for (let r = 0; r < this.rows; r++) {
       for (let c = 0; c < this.cols; c++) {
         const idx = r * this.cols + c
         const cell = view[idx]
-        const state: TileState = cell === 1 ? 'black' : cell === 2 ? 'white' : 'empty'
+        const newState: TileState = cell === 1 ? 'black' : cell === 2 ? 'white' : 'empty'
+        const tile = this.tiles[r][c]
+
+        if (tile.state !== 'empty' && newState === 'empty') {
+          vanishing.push(tile)
+        }
+      }
+    }
+
+    // Stagger vanish: accelerating delays (first slow, last fast)
+    // Delay formula: quadratic spacing so gaps shrink toward the end
+    const vanishCount = vanishing.length
+    if (vanishCount > 0) {
+      const totalStagger = Math.min(vanishCount * 0.08, 0.5) // cap total stagger
+      for (let i = 0; i < vanishCount; i++) {
+        // Quadratic: early stones get more time, later ones are rapid
+        const frac = vanishCount > 1 ? i / (vanishCount - 1) : 0
+        const delay = totalStagger * (1 - (1 - frac) ** 2)
+        // Stones later in the sequence also vanish faster
+        const dur = 0.3 - 0.1 * frac // 0.3s → 0.2s
+        vanishing[i].startVanish(delay, dur)
+      }
+    }
+
+    // Second pass: apply new states for non-vanishing tiles
+    for (let r = 0; r < this.rows; r++) {
+      for (let c = 0; c < this.cols; c++) {
+        const idx = r * this.cols + c
+        const cell = view[idx]
+        const newState: TileState = cell === 1 ? 'black' : cell === 2 ? 'white' : 'empty'
+        const tile = this.tiles[r][c]
+
+        // Skip tiles that are vanishing — they'll clean themselves up
+        if (tile.state !== 'empty' && newState === 'empty') continue
+
         const anim = dropOverrides?.has(idx) ? 'drop' as StoneAnim : defaultAnim
-        this.tiles[r][c].setState(state, false, anim)
+        tile.setState(newState, false, anim)
         if (idx === collisionIndex) {
-          this.tiles[r][c].flashCollision()
+          tile.flashCollision()
         }
       }
     }

--- a/game/src/board/HexTile.ts
+++ b/game/src/board/HexTile.ts
@@ -164,33 +164,52 @@ export class HexTile3D {
       this._stoneDropTimer += dt
 
       if (this._stoneAnim === 'drop') {
-        // ── Drop from above with bounce ────────────────────────────────
+        // ── Phase 1: Materialize (0–0.15s) then Phase 2: Fall+bounce ───
+        const matDur = 0.30  // materialize duration (needs time for elastic bounce)
         const dropH = 1.2
-        const dur = 0.35
-        const t = Math.min(this._stoneDropTimer / dur, 1)
+        const fallDur = 0.35 // fall+bounce duration
+        const timer = this._stoneDropTimer
 
-        // Fire landing sound at first impact
-        if (t >= 0.5 && !this._dropLanded) {
-          this._dropLanded = true
-          this.onDropLand?.()
-        }
-
-        let y: number
-        if (t < 0.5) {
-          const ft = t / 0.5
-          y = this._stoneRestY + dropH * (1 - ft * ft)
-        } else if (t < 0.75) {
-          const bt = (t - 0.5) / 0.25
-          y = this._stoneRestY + dropH * 0.12 * Math.sin(bt * Math.PI)
+        if (timer < matDur) {
+          // Elastic scale-up: overshoots to ~1.3, bounces back, settles at 1.0
+          const mt = timer / matDur
+          // Elastic ease-out: decaying sine oscillation
+          const p = 0.3  // oscillation period
+          const s = p / 4
+          const elastic = Math.pow(2, -10 * mt) * Math.sin((mt - s) * (2 * Math.PI) / p) + 1
+          this.stoneGroup.scale.setScalar(Math.max(0, elastic))
+          // Stay in place at the top
+          this.stoneGroup.position.y = this._stoneRestY + dropH
         } else {
-          const bt = (t - 0.75) / 0.25
-          y = this._stoneRestY + dropH * 0.03 * Math.sin(bt * Math.PI)
-        }
-        this.stoneGroup.position.y = y
+          // Full scale
+          this.stoneGroup.scale.setScalar(1)
 
-        if (t >= 1) {
-          this.stoneGroup.position.y = this._stoneRestY
-          this._stoneDropTimer = -1
+          const ft = Math.min((timer - matDur) / fallDur, 1)
+
+          // Fire landing sound at first impact
+          if (ft >= 0.5 && !this._dropLanded) {
+            this._dropLanded = true
+            this.onDropLand?.()
+          }
+
+          let y: number
+          if (ft < 0.5) {
+            const f = ft / 0.5
+            y = this._stoneRestY + dropH * (1 - f * f)
+          } else if (ft < 0.75) {
+            const bt = (ft - 0.5) / 0.25
+            y = this._stoneRestY + dropH * 0.12 * Math.sin(bt * Math.PI)
+          } else {
+            const bt = (ft - 0.75) / 0.25
+            y = this._stoneRestY + dropH * 0.03 * Math.sin(bt * Math.PI)
+          }
+          this.stoneGroup.position.y = y
+
+          if (ft >= 1) {
+            this.stoneGroup.position.y = this._stoneRestY
+            this.stoneGroup.scale.setScalar(1)
+            this._stoneDropTimer = -1
+          }
         }
 
       }
@@ -303,7 +322,7 @@ export class HexTile3D {
     if (anim === 'drop') {
       // ── Drop from above — player's action ────────────────────────────
       this.stoneGroup.position.set(0, this._stoneRestY + 1.2, 0)
-      this.stoneGroup.scale.setScalar(1)
+      this.stoneGroup.scale.setScalar(0.01)  // materializes from nothing
       this._stoneDropTimer = 0.001
       this._stoneAnim = 'drop'
       this._dropLanded = false

--- a/game/src/board/HexTile.ts
+++ b/game/src/board/HexTile.ts
@@ -4,6 +4,9 @@ import { toonMat } from './ToonMaterials'
 
 export type TileState = 'empty' | 'black' | 'white'
 
+/** How a newly placed stone should animate in. */
+export type StoneAnim = 'drop' | 'rise' | 'none'
+
 // ── Shared geometries ───────────────────────────────────────────────────────
 
 let _tileGeo: THREE.ExtrudeGeometry | null = null
@@ -69,6 +72,15 @@ export class HexTile3D {
   private stoneGroup: THREE.Group | null = null
   private _baseY = 0
   private _collisionTimer = 0
+  private _stoneDropTimer = 0        // > 0 while drop/animation is active
+  private _stoneRestY = 0            // final resting Y of the stone group
+  private _stoneAnim: StoneAnim = 'drop'
+  private _dropLanded = false        // true once landing triggers
+  private _flipTimer = -1            // > 0 while tile flip is active
+  private _flipPivot: THREE.Group | null = null  // pivot for flip rotation
+
+  /** Called when the stone first hits the board (at the bounce point). */
+  onDropLand: (() => void) | null = null
 
   constructor(row: number, col: number, cellIndex: number) {
     this.row = row
@@ -91,7 +103,10 @@ export class HexTile3D {
 
   get selected(): boolean { return this._selected }
 
-  setState(s: TileState, isLast = false): void {
+  get stoneAnim(): StoneAnim { return this._stoneAnim }
+
+  setState(s: TileState, isLast = false, anim: StoneAnim = 'drop'): void {
+    const changed = s !== this._state
     this._state = s
     this._isLast = isLast
     this._hovered = false
@@ -99,7 +114,7 @@ export class HexTile3D {
     // Reset tile to base height (e.g. if it was hovered/selected when stone placed)
     this.group.userData['targetY'] = this._baseY
     this._updateColors()
-    this._updateStone()
+    if (changed) this._updateStone(anim)
   }
 
   setSelected(s: boolean): void {
@@ -144,6 +159,79 @@ export class HexTile3D {
       }
     }
 
+    // Stone placement animation (drop from above or rise from below)
+    if (this._stoneDropTimer >= 0 && this.stoneGroup) {
+      this._stoneDropTimer += dt
+
+      if (this._stoneAnim === 'drop') {
+        // ── Drop from above with bounce ────────────────────────────────
+        const dropH = 1.2
+        const dur = 0.35
+        const t = Math.min(this._stoneDropTimer / dur, 1)
+
+        // Fire landing sound at first impact
+        if (t >= 0.5 && !this._dropLanded) {
+          this._dropLanded = true
+          this.onDropLand?.()
+        }
+
+        let y: number
+        if (t < 0.5) {
+          const ft = t / 0.5
+          y = this._stoneRestY + dropH * (1 - ft * ft)
+        } else if (t < 0.75) {
+          const bt = (t - 0.5) / 0.25
+          y = this._stoneRestY + dropH * 0.12 * Math.sin(bt * Math.PI)
+        } else {
+          const bt = (t - 0.75) / 0.25
+          y = this._stoneRestY + dropH * 0.03 * Math.sin(bt * Math.PI)
+        }
+        this.stoneGroup.position.y = y
+
+        if (t >= 1) {
+          this.stoneGroup.position.y = this._stoneRestY
+          this._stoneDropTimer = -1
+        }
+
+      }
+    }
+
+    // Tile flip animation (rise/reveal)
+    if (this._flipTimer >= 0 && this._flipPivot) {
+      this._flipTimer += dt
+      const dur = 0.9
+      const t = Math.min(this._flipTimer / dur, 1)
+
+      // Ease-out quart — fast start, smooth settle
+      const ease = 1 - (1 - t) ** 4
+
+      // Rotate 0 → PI around X axis (stone swings from below to above)
+      this._flipPivot.rotation.x = Math.PI * ease
+
+      // Fire sound at 90°
+      if (ease >= 0.5 && !this._dropLanded) {
+        this._dropLanded = true
+        this.onDropLand?.()
+      }
+
+      if (t >= 1) {
+        // Flip done — reparent back to group at normal positions
+        this._flipPivot.remove(this.mesh)
+        this.mesh.position.y = 0
+        this.group.add(this.mesh)
+
+        if (this.stoneGroup) {
+          this._flipPivot.remove(this.stoneGroup)
+          this.stoneGroup.position.set(0, this._stoneRestY, 0)
+          this.group.add(this.stoneGroup)
+        }
+
+        this.group.remove(this._flipPivot)
+        this._flipPivot = null
+        this._flipTimer = -1
+      }
+    }
+
     // Collision flash
     if (this._collisionTimer > 0) {
       this._collisionTimer -= dt
@@ -175,7 +263,17 @@ export class HexTile3D {
     }
   }
 
-  private _updateStone(): void {
+  private _updateStone(anim: StoneAnim = 'drop'): void {
+    // Clean up any in-progress flip
+    if (this._flipPivot) {
+      this._flipPivot.remove(this.mesh)
+      if (this.stoneGroup) this._flipPivot.remove(this.stoneGroup)
+      this.group.remove(this._flipPivot)
+      this.group.add(this.mesh)
+      this._flipPivot = null
+      this._flipTimer = -1
+    }
+
     if (this.stoneGroup) {
       this.stoneGroup.traverse(obj => {
         if (obj instanceof THREE.Mesh) {
@@ -198,7 +296,62 @@ export class HexTile3D {
 
     this.stoneGroup = new THREE.Group()
     this.stoneGroup.add(stoneMesh)
-    this.stoneGroup.position.set(0, HEX.STONE_H + HEX.STONE_LIP + HEX.TILE_LIP + 0.08, 0)
-    this.group.add(this.stoneGroup)
+
+    // Final resting Y within the tile group
+    this._stoneRestY = HEX.STONE_H + HEX.STONE_LIP + HEX.TILE_LIP + 0.08
+
+    if (anim === 'drop') {
+      // ── Drop from above — player's action ────────────────────────────
+      this.stoneGroup.position.set(0, this._stoneRestY + 1.2, 0)
+      this.stoneGroup.scale.setScalar(1)
+      this._stoneDropTimer = 0.001
+      this._stoneAnim = 'drop'
+      this._dropLanded = false
+      this.group.add(this.stoneGroup)
+
+    } else if (anim === 'rise') {
+      // ── Tile flip — stone attached underneath, both rotate together ──
+      //
+      // How it works:
+      //   1. Stone is placed at -stoneRestY (below tile) in the pivot
+      //   2. Pivot starts at rotation.x = 0 (stone is underneath, hidden)
+      //   3. Pivot rotates from 0 → PI around X axis
+      //   4. At PI, local -Y maps to world +Y = stone ends up on top
+      //   5. Tile is upside-down but looks identical (symmetric hex prism)
+      //
+      this._stoneAnim = 'rise'
+      this._dropLanded = false
+
+      this.stoneGroup.scale.setScalar(1)
+
+      // Pivot at the vertical center of the tile so it rotates in place.
+      const pivotY = HEX.HEIGHT / 2
+      this._flipPivot = new THREE.Group()
+      this._flipPivot.position.y = pivotY
+
+      this.group.remove(this.mesh)
+      this.mesh.position.y = -pivotY
+      // Stone underneath: top of stone must be at or below tile bottom (-pivotY).
+      // Stone mesh top is at pos + STONE_H + STONE_LIP relative to stoneGroup origin.
+      // So pos = -pivotY - (STONE_H + STONE_LIP)
+      this.stoneGroup.position.set(0, -pivotY - HEX.STONE_H - HEX.STONE_LIP, 0)
+
+      this._flipPivot.add(this.mesh)
+      this._flipPivot.add(this.stoneGroup)
+      this._flipPivot.rotation.x = 0
+      this.group.add(this._flipPivot)
+
+      this._flipTimer = 0.001
+      this._stoneDropTimer = -1
+
+    } else {
+      // ── No animation — snap to position ──────────────────────────────
+      this.stoneGroup.position.set(0, this._stoneRestY, 0)
+      this.stoneGroup.scale.setScalar(1)
+      this._stoneDropTimer = -1
+      this.group.add(this.stoneGroup)
+    }
+    // NOTE: each branch adds stoneGroup to the correct parent.
+    // Do NOT add this.group.add(this.stoneGroup) here.
   }
 }

--- a/game/src/board/HexTile.ts
+++ b/game/src/board/HexTile.ts
@@ -111,6 +111,7 @@ export class HexTile3D {
 
   setState(s: TileState, isLast = false, anim: StoneAnim = 'drop'): void {
     const changed = s !== this._state
+    const wasVanishing = this._vanishTimer > -99
     this._state = s
     this._isLast = isLast
     this._hovered = false
@@ -119,7 +120,13 @@ export class HexTile3D {
     // Reset tile to base height (e.g. if it was hovered/selected when stone placed)
     this.group.userData['targetY'] = this._baseY
     this._updateColors()
-    if (changed) this._updateStone(anim)
+    if (changed) {
+      this._updateStone(anim)
+    } else if (wasVanishing && this.stoneGroup) {
+      // Vanish was cancelled but state didn't change — restore stone transform
+      this.stoneGroup.position.set(0, this._stoneRestY, 0)
+      this.stoneGroup.scale.setScalar(1)
+    }
   }
 
   setSelected(s: boolean): void {
@@ -335,11 +342,12 @@ export class HexTile3D {
   }
 
   private _updateStone(anim: StoneAnim = 'drop'): void {
-    // Clean up any in-progress flip
+    // Clean up any in-progress flip — reset mesh position to normal
     if (this._flipPivot) {
       this._flipPivot.remove(this.mesh)
       if (this.stoneGroup) this._flipPivot.remove(this.stoneGroup)
       this.group.remove(this._flipPivot)
+      this.mesh.position.y = 0  // reset from -pivotY offset
       this.group.add(this.mesh)
       this._flipPivot = null
       this._flipTimer = -1

--- a/game/src/board/HexTile.ts
+++ b/game/src/board/HexTile.ts
@@ -78,6 +78,8 @@ export class HexTile3D {
   private _dropLanded = false        // true once landing triggers
   private _flipTimer = -1            // > 0 while tile flip is active
   private _flipPivot: THREE.Group | null = null  // pivot for flip rotation
+  private _vanishTimer = -1          // > 0 while vanish animation is active
+  private _vanishDur = 0.3           // per-stone vanish duration
 
   /** Called when the stone first hits the board (at the bounce point). */
   onDropLand: (() => void) | null = null
@@ -143,6 +145,17 @@ export class HexTile3D {
   /** Trigger a collision flash animation (amber flash for ~0.4s). */
   flashCollision(): void {
     this._collisionTimer = 0.4
+  }
+
+  /**
+   * Start a vanish animation: stone floats up + shrinks away.
+   * @param delay seconds before the animation starts (for staggering)
+   * @param dur how long the vanish takes once it starts
+   */
+  startVanish(delay: number, dur = 0.3): void {
+    if (!this.stoneGroup) return
+    this._vanishTimer = -delay  // negative = waiting for delay
+    this._vanishDur = dur
   }
 
   tickAnimation(dt: number): void {
@@ -248,6 +261,39 @@ export class HexTile3D {
         this.group.remove(this._flipPivot)
         this._flipPivot = null
         this._flipTimer = -1
+      }
+    }
+
+    // Vanish animation (stone floats up + shrinks away)
+    if (this._vanishTimer > -99 && this._vanishTimer < 100 && this.stoneGroup) {
+      this._vanishTimer += dt
+      if (this._vanishTimer >= 0) {
+        // Animation active
+        const t = Math.min(this._vanishTimer / this._vanishDur, 1)
+        // Ease-in quad: starts slow, accelerates away
+        const ease = t * t
+
+        // Float upward
+        this.stoneGroup.position.y = this._stoneRestY + ease * 1.0
+
+        // Shrink to nothing with slight acceleration
+        this.stoneGroup.scale.setScalar(Math.max(0, 1 - ease))
+
+        if (t >= 1) {
+          // Remove the stone and set state to empty
+          this.stoneGroup.traverse(obj => {
+            if (obj instanceof THREE.Mesh) {
+              const mat = obj.material
+              if (Array.isArray(mat)) mat.forEach(m => m.dispose())
+              else mat.dispose()
+            }
+          })
+          this.group.remove(this.stoneGroup)
+          this.stoneGroup = null
+          this._state = 'empty'
+          this._updateColors()
+          this._vanishTimer = -99  // done
+        }
       }
     }
 

--- a/game/src/board/HexTile.ts
+++ b/game/src/board/HexTile.ts
@@ -78,7 +78,7 @@ export class HexTile3D {
   private _dropLanded = false        // true once landing triggers
   private _flipTimer = -1            // > 0 while tile flip is active
   private _flipPivot: THREE.Group | null = null  // pivot for flip rotation
-  private _vanishTimer = -1          // > 0 while vanish animation is active
+  private _vanishTimer = -99         // -99 = inactive; negative = waiting for delay; positive = animating
   private _vanishDur = 0.3           // per-stone vanish duration
 
   /** Called when the stone first hits the board (at the bounce point). */
@@ -113,6 +113,7 @@ export class HexTile3D {
     this._isLast = isLast
     this._hovered = false
     this._selected = false
+    this._vanishTimer = -99  // cancel any active vanish
     // Reset tile to base height (e.g. if it was hovered/selected when stone placed)
     this.group.userData['targetY'] = this._baseY
     this._updateColors()

--- a/game/src/board/HexTile.ts
+++ b/game/src/board/HexTile.ts
@@ -83,6 +83,8 @@ export class HexTile3D {
 
   /** Called when the stone first hits the board (at the bounce point). */
   onDropLand: (() => void) | null = null
+  /** Called when a stone starts vanishing. */
+  onVanishStart: (() => void) | null = null
 
   constructor(row: number, col: number, cellIndex: number) {
     this.row = row
@@ -267,8 +269,11 @@ export class HexTile3D {
 
     // Vanish animation (stone floats up + shrinks away)
     if (this._vanishTimer > -99 && this._vanishTimer < 100 && this.stoneGroup) {
+      const wasBefore = this._vanishTimer < 0
       this._vanishTimer += dt
       if (this._vanishTimer >= 0) {
+        // Fire sound on first active frame
+        if (wasBefore) this.onVanishStart?.()
         // Animation active
         const t = Math.min(this._vanishTimer / this._vanishDur, 1)
         // Ease-in quad: starts slow, accelerates away

--- a/game/src/scenes/BoardScene.ts
+++ b/game/src/scenes/BoardScene.ts
@@ -9,6 +9,7 @@ import { StrategyGenerator } from '../strategy/StrategyGenerator'
 import { SetupPanel } from '../ui/SetupPanel'
 import { ActionPanel } from '../ui/ActionPanel'
 import { InfoPanel } from '../ui/InfoPanel'
+import { ensureAudioReady, playThock, playPlace, playDrop, playReveal } from '../audio/SoundEngine'
 
 const BOARD_ROWS = 4
 const BOARD_COLS = 3
@@ -196,12 +197,16 @@ export class BoardScene {
     const tile = this._raycastTile()
     if (tile !== this.hoveredTile) {
       if (this.hoveredTile) this.hoveredTile.setHovered(false)
-      if (tile) tile.setHovered(true)
+      if (tile && tile.state === 'empty') {
+        tile.setHovered(true)
+        playThock()
+      }
       this.hoveredTile = tile
     }
   }
 
   private _onPointerDown = (e: PointerEvent): void => {
+    ensureAudioReady()
     this._updatePointer(e)
     const tile = this._raycastTile()
     if (!tile) return
@@ -216,6 +221,7 @@ export class BoardScene {
     if (isDoubleClick) {
       // Double-click: instant deterministic action
       this._clearSelection()
+      playPlace()
       this._handleConfirm([tile.cellIndex], [1.0])
       return
     }
@@ -227,6 +233,7 @@ export class BoardScene {
     } else {
       this.selectedTiles.set(tile.cellIndex, 1)
       tile.setSelected(true)
+      playPlace()
     }
     this._syncSelectionUI()
   }
@@ -259,6 +266,14 @@ export class BoardScene {
     this._clearBoardFromScene()
     this.board = new BoardLayout3D(this.scene, rows, cols)
     this.outlineRender.invalidateMeshList()
+
+    // Wire up landing sounds on all tiles (drop = clack, rise = soft reveal)
+    for (const tile of this.board.allTiles()) {
+      tile.onDropLand = () => {
+        if (tile.stoneAnim === 'rise') playReveal()
+        else playDrop()
+      }
+    }
 
     const [cx, , cz] = boardCenter(rows, cols)
     const dist = 14
@@ -327,7 +342,12 @@ export class BoardScene {
     try {
       const complete = this.stratGen.submitActions(actions, probs)
       this._clearSelection()
-      this._updateStrategyView()
+      // Collision cells should rise (already there), not drop
+      const dropCells = new Set(actions)
+      if (this.stratGen.lastCollisionIndex !== null) {
+        dropCells.delete(this.stratGen.lastCollisionIndex)
+      }
+      this._updateStrategyView(dropCells)
       if (complete) this._showExportDialog()
     } catch (err) {
       console.error('Strategy action error:', err)
@@ -430,10 +450,11 @@ export class BoardScene {
     }
   }
 
-  private _updateStrategyView(): void {
+  /** @param playerActions cells the player just acted on (drop anim); others rise */
+  private _updateStrategyView(playerActions?: Set<number>): void {
     if (!this.stratGen) return
     const view = this.stratGen.boardView
-    this.board.applyView(view, this.stratGen.lastCollisionIndex)
+    this.board.applyView(view, this.stratGen.lastCollisionIndex, 'rise', playerActions)
 
     const { assigned, remaining } = this.stratGen.progress
     this.actionPanel.updateSelection(this.selectedTiles, this.stratGen.cols)

--- a/game/src/scenes/BoardScene.ts
+++ b/game/src/scenes/BoardScene.ts
@@ -9,7 +9,7 @@ import { StrategyGenerator } from '../strategy/StrategyGenerator'
 import { SetupPanel } from '../ui/SetupPanel'
 import { ActionPanel } from '../ui/ActionPanel'
 import { InfoPanel } from '../ui/InfoPanel'
-import { ensureAudioReady, playThock, playPlace, playDrop, playReveal } from '../audio/SoundEngine'
+import { ensureAudioReady, playThock, playPlace, playDrop, playReveal, playVanish } from '../audio/SoundEngine'
 
 const BOARD_ROWS = 4
 const BOARD_COLS = 3
@@ -267,12 +267,13 @@ export class BoardScene {
     this.board = new BoardLayout3D(this.scene, rows, cols)
     this.outlineRender.invalidateMeshList()
 
-    // Wire up landing sounds on all tiles (drop = clack, rise = soft reveal)
+    // Wire up sounds on all tiles
     for (const tile of this.board.allTiles()) {
       tile.onDropLand = () => {
         if (tile.stoneAnim === 'rise') playReveal()
         else playDrop()
       }
+      tile.onVanishStart = () => playVanish()
     }
 
     const [cx, , cz] = boardCenter(rows, cols)

--- a/game/src/ui/InfoPanel.ts
+++ b/game/src/ui/InfoPanel.ts
@@ -112,10 +112,11 @@ export class InfoPanel {
 
     this.collisionEl.style.display = state.isCollision ? 'inline' : 'none'
 
-    // Show action history for perfect recall (third line of info state string)
+    // Show action history for perfect recall (last line of info state string)
+    // Format: P{player}\n{row1}\n...\n{rowN}\n{history}
     if (state.perfectRecall) {
       const lines = state.infoState.split('\n')
-      const historyLine = lines.length >= 3 ? lines[2].trim() : ''
+      const historyLine = lines.length >= 3 ? lines[lines.length - 1].trim() : ''
       if (historyLine) {
         this.historyEl.textContent = `History: ${historyLine}`
         this.historyEl.style.display = 'block'


### PR DESCRIPTION
## Summary

- **Synthesized sounds** via Web Audio API — no external files:
  - Wooden thock on tile hover
  - Deeper knock on tile selection
  - Clack on stone drop landing
  - Muffled reveal on tile flip
  - Airy whoosh on stone vanish
- **Stone drop animation**: materializes with elastic bounce in the air, then falls with double bounce
- **Tile flip animation**: pre-existing stones (collisions, state navigation) revealed by flipping the tile 180° with stone attached underneath
- **Staggered vanish**: disappearing stones float up + shrink away with accelerating delays (first slow, last rapid)
- **Codex review fixes**: action history shown for perfect recall, Enter blocked during setup modal

## Test plan
- [ ] Hover empty tiles — hear soft wooden thock
- [ ] Select tile — hear deeper knock
- [ ] Double-click confirm — stone materializes (elastic bounce), falls, bounces, clack
- [ ] Advance to state with pre-existing stones — tiles flip to reveal stones underneath
- [ ] Collision — tile flips (not drops) + muffled sound
- [ ] Undo/restart — stones vanish with staggered float-up + whoosh cascade
- [ ] Perfect recall mode — history line shown in top bar
- [ ] Enter key doesn't trigger during setup modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)