### PR TITLE
feat(game): strategy completion flow with modal, chime, and safety guards

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -279,6 +279,8 @@ Ported from the old Python/Tkinter `darkhex/gui/` PolGen tool. Lets researchers 
 | Board-centric UX | Click tiles, overlays on 3D board | Researchers see the board as the player sees it, not an abstract tree |
 
 **Planned features**:
+- Strategy investigation screen (browse completed strategy: step through info states, view assigned probabilities on the board, navigate the decision tree)
+- Strategy diagram export (generate visual game tree / strategy diagrams as SVG/PDF, similar to thesis figures — show info states, branching, and probability assignments)
 - Strategy walker (step through MCCFR policies)
 - Game tree exploration
 - Live MCCFR convergence plots

--- a/game/src/audio/SoundEngine.ts
+++ b/game/src/audio/SoundEngine.ts
@@ -376,3 +376,42 @@ export function playCollision(): void {
   osc.start(now)
   osc.stop(now + 0.08)
 }
+
+// ── Celebration chime (strategy complete) ──────────────────────────────────
+
+/**
+ * Warm, ascending three-note chime — "you did it!"
+ * Major triad arpeggio with gentle sine tones.
+ */
+export function playChime(): void {
+  const c = ctx()
+  if (c.state !== 'running') return
+  const now = c.currentTime
+
+  const master = c.createGain()
+  master.gain.setValueAtTime(0.12, now)
+  master.connect(c.destination)
+
+  // Three ascending notes: C5 → E5 → G5 (major triad)
+  const notes = [523.25, 659.25, 783.99]
+  const noteDelay = 0.12  // stagger between notes
+  const noteDur = 0.4
+
+  for (let i = 0; i < notes.length; i++) {
+    const t = now + i * noteDelay
+
+    const osc = c.createOscillator()
+    osc.type = 'sine'
+    osc.frequency.setValueAtTime(notes[i], t)
+
+    const gain = c.createGain()
+    gain.gain.setValueAtTime(0, t)
+    gain.gain.linearRampToValueAtTime(0.8, t + 0.03)       // quick attack
+    gain.gain.exponentialRampToValueAtTime(0.001, t + noteDur)  // gentle decay
+
+    osc.connect(gain)
+    gain.connect(master)
+    osc.start(t)
+    osc.stop(t + noteDur)
+  }
+}

--- a/game/src/scenes/BoardScene.ts
+++ b/game/src/scenes/BoardScene.ts
@@ -9,7 +9,8 @@ import { StrategyGenerator } from '../strategy/StrategyGenerator'
 import { SetupPanel } from '../ui/SetupPanel'
 import { ActionPanel } from '../ui/ActionPanel'
 import { InfoPanel } from '../ui/InfoPanel'
-import { ensureAudioReady, playThock, playPlace, playDrop, playReveal, playVanish } from '../audio/SoundEngine'
+import { CompletionPanel } from '../ui/CompletionPanel'
+import { ensureAudioReady, playThock, playPlace, playDrop, playReveal, playVanish, playChime } from '../audio/SoundEngine'
 
 const BOARD_ROWS = 4
 const BOARD_COLS = 3
@@ -41,6 +42,7 @@ export class BoardScene {
   private setupPanel!: SetupPanel
   private actionPanel!: ActionPanel
   private infoPanel!: InfoPanel
+  private completionPanel!: CompletionPanel
   private selectedTiles: Map<number, number> = new Map() // cellIndex → 1 (tracked for selection)
   private probOverlay!: HTMLDivElement // container for probability labels
   private probLabels: Map<number, HTMLDivElement> = new Map()
@@ -113,6 +115,7 @@ export class BoardScene {
     this.setupPanel = new SetupPanel(this.container)
     this.actionPanel = new ActionPanel(this.container)
     this.infoPanel = new InfoPanel(this.container)
+    this.completionPanel = new CompletionPanel(this.container)
 
     // Probability overlay container (positioned over canvas)
     this.probOverlay = document.createElement('div')
@@ -349,7 +352,7 @@ export class BoardScene {
         dropCells.delete(this.stratGen.lastCollisionIndex)
       }
       this._updateStrategyView(dropCells)
-      if (complete) this._showExportDialog()
+      if (complete) this._showCompletionFlow()
     } catch (err) {
       console.error('Strategy action error:', err)
     }
@@ -362,7 +365,7 @@ export class BoardScene {
       this._clearSelection()
       this._updateStrategyView()
       if (complete) {
-        this._showExportDialog()
+        this._showCompletionFlow()
       }
     } catch (err) {
       console.error('Strategy action error:', err)
@@ -469,7 +472,29 @@ export class BoardScene {
     })
   }
 
-  private _showExportDialog(): void {
+  private async _showCompletionFlow(): Promise<void> {
+    if (!this.stratGen) return
+
+    // Play celebration chime
+    playChime()
+
+    // Show completion panel with stats
+    const { assigned } = this.stratGen.progress
+    const action = await this.completionPanel.show({
+      player: this.stratGen.player,
+      rows: this.stratGen.rows,
+      cols: this.stratGen.cols,
+      infoStates: assigned,
+    })
+
+    if (action === 'download') {
+      this._downloadPolicy()
+    } else if (action === 'new') {
+      this._restartStrategyMode()
+    }
+  }
+
+  private _downloadPolicy(): void {
     if (!this.stratGen) return
     const policy = this.stratGen.exportPolicy()
     const json = JSON.stringify(policy, null, 2)
@@ -479,7 +504,6 @@ export class BoardScene {
     a.href = url
     a.download = `policy_${this.stratGen.rows}x${this.stratGen.cols}_p${this.stratGen.player}.json`
     a.click()
-    // Defer revocation so the browser has time to start the download
     setTimeout(() => URL.revokeObjectURL(url), 5000)
   }
 

--- a/game/src/scenes/BoardScene.ts
+++ b/game/src/scenes/BoardScene.ts
@@ -478,8 +478,9 @@ export class BoardScene {
 
     // Play celebration chime
     playChime()
+    this.completionPanel.resetDownloaded()
 
-    // Loop: re-show completion modal if user cancels the setup dialog
+    // Loop: re-show completion modal if user cancels the setup dialog or dismisses
     while (true) {
       this._completionOpen = true
       const { assigned } = this.stratGen!.progress
@@ -525,7 +526,9 @@ export class BoardScene {
         this._updateStrategyView()
         return
       } else {
-        return  // dismissed
+        // Dismissed — let user keep inspecting the completed board
+        this._completionOpen = false
+        return
       }
     }
   }

--- a/game/src/scenes/BoardScene.ts
+++ b/game/src/scenes/BoardScene.ts
@@ -38,6 +38,7 @@ export class BoardScene {
 
   // Strategy mode
   private _setupOpen = false
+  private _completionOpen = false
   private stratGen: StrategyGenerator | null = null
   private setupPanel!: SetupPanel
   private actionPanel!: ActionPanel
@@ -242,7 +243,7 @@ export class BoardScene {
   }
 
   private _onKeyDown = (e: KeyboardEvent): void => {
-    if (this._setupOpen) return
+    if (this._setupOpen || this._completionOpen) return
     if (e.key === 'Escape') this._restartStrategyMode()
     if (e.key === 'Enter' && this.selectedTiles.size > 0) {
       const result = this.actionPanel.getActionProbs()
@@ -478,19 +479,54 @@ export class BoardScene {
     // Play celebration chime
     playChime()
 
-    // Show completion panel with stats
-    const { assigned } = this.stratGen.progress
-    const action = await this.completionPanel.show({
-      player: this.stratGen.player,
-      rows: this.stratGen.rows,
-      cols: this.stratGen.cols,
-      infoStates: assigned,
-    })
+    // Loop: re-show completion modal if user cancels the setup dialog
+    while (true) {
+      this._completionOpen = true
+      const { assigned } = this.stratGen!.progress
+      const action = await this.completionPanel.show({
+        player: this.stratGen!.player,
+        rows: this.stratGen!.rows,
+        cols: this.stratGen!.cols,
+        infoStates: assigned,
+      })
+      this._completionOpen = false
 
-    if (action === 'download') {
-      this._downloadPolicy()
-    } else if (action === 'new') {
-      this._restartStrategyMode()
+      if (action === 'download') {
+        this._downloadPolicy()
+        // After download, re-show the modal so user can still start new
+        continue
+      } else if (action === 'new') {
+        // Try to start new — if user cancels setup, loop back to completion
+        this.actionPanel.hide()
+        this.infoPanel.hide()
+
+        this._setupOpen = true
+        const config = await this.setupPanel.show(true)
+        this._setupOpen = false
+
+        if (!config) {
+          // Cancelled — restore panels and re-show completion
+          this.actionPanel.show()
+          this.infoPanel.show()
+          continue
+        }
+
+        // New config chosen — tear down and start fresh
+        this._clearSelection()
+        for (const el of this.probLabels.values()) el.remove()
+        this.probLabels.clear()
+        this.stratGen = null
+
+        this._rebuildBoard(config.rows, config.cols)
+        const infoOps = await InfoStateOps.create(config.rows, config.cols)
+        this.stratGen = new StrategyGenerator(infoOps, config)
+        this.actionPanel.show()
+        this.infoPanel.show()
+        this._updateStrategyView()
+        return
+      } else {
+        return  // dismissed
+      }
     }
   }
 

--- a/game/src/ui/CompletionPanel.ts
+++ b/game/src/ui/CompletionPanel.ts
@@ -1,0 +1,156 @@
+// ── Shared style tokens ────────────────────────────────────────────────────
+const FONT = "'Nunito', -apple-system, BlinkMacSystemFont, sans-serif"
+const CREAM = '#faf5ef'
+const MAUVE_DARK = '#995a5a'
+const MAUVE_LIGHT = '#e8d5d5'
+const TEXT = '#4a3535'
+const TEXT_MUTED = '#8a7070'
+const GREEN = '#5a9a5e'
+const GREEN_LIGHT = '#e8f5e9'
+const GREEN_BORDER = '#b5d8b7'
+const SHADOW = '0 8px 32px rgba(100, 60, 60, 0.18), 0 2px 8px rgba(100, 60, 60, 0.10)'
+
+export interface CompletionStats {
+  player: number
+  rows: number
+  cols: number
+  infoStates: number
+}
+
+export type CompletionAction = 'download' | 'new' | 'dismiss'
+
+/**
+ * Completion modal shown when a strategy is fully built.
+ * Shows stats and offers download / new strategy options.
+ */
+export class CompletionPanel {
+  private overlay: HTMLDivElement
+  private statsEl: HTMLDivElement
+  private resolve: ((action: CompletionAction) => void) | null = null
+
+  constructor(parent: HTMLElement) {
+    this.overlay = document.createElement('div')
+    this.overlay.style.cssText = `
+      display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%;
+      background: rgba(180, 160, 140, 0.45); backdrop-filter: blur(4px);
+      z-index: 100; align-items: center; justify-content: center;
+    `
+
+    const panel = document.createElement('div')
+    panel.style.cssText = `
+      background: ${CREAM}; border-radius: 14px; padding: 36px 40px;
+      min-width: 360px; max-width: 440px; text-align: center;
+      box-shadow: ${SHADOW}; border: 2px solid ${GREEN_BORDER};
+      font-family: ${FONT}; color: ${TEXT};
+    `
+
+    // ── Title ──────────────────────────────────────────────────────────
+    const title = document.createElement('h2')
+    title.textContent = 'Strategy Complete!'
+    title.style.cssText = `
+      margin: 0 0 8px; font-size: 24px; font-weight: 800;
+      color: ${GREEN}; letter-spacing: -0.3px;
+    `
+    panel.appendChild(title)
+
+    const subtitle = document.createElement('p')
+    subtitle.textContent = 'All information states have been assigned.'
+    subtitle.style.cssText = `margin: 0 0 24px; color: ${TEXT_MUTED}; font-size: 15px;`
+    panel.appendChild(subtitle)
+
+    // ── Stats ──────────────────────────────────────────────────────────
+    this.statsEl = document.createElement('div')
+    this.statsEl.style.cssText = `
+      display: flex; justify-content: center; gap: 24px;
+      margin-bottom: 28px; padding: 16px 20px;
+      background: ${GREEN_LIGHT}; border: 1px solid ${GREEN_BORDER};
+      border-radius: 10px;
+    `
+    panel.appendChild(this.statsEl)
+
+    // ── Buttons ────────────────────────────────────────────────────────
+    const btnRow = document.createElement('div')
+    btnRow.style.cssText = 'display: flex; gap: 10px;'
+
+    const downloadBtn = this._makeBtn('Download JSON', MAUVE_DARK, '#fff', `
+      flex: 2; font-weight: 800;
+      box-shadow: 0 3px 0 #7a4040, 0 4px 12px rgba(100, 60, 60, 0.2);
+    `)
+    downloadBtn.addEventListener('mousedown', () => {
+      downloadBtn.style.transform = 'translateY(2px)'
+      downloadBtn.style.boxShadow = '0 1px 0 #7a4040, 0 2px 6px rgba(100, 60, 60, 0.2)'
+    })
+    downloadBtn.addEventListener('mouseup', () => {
+      downloadBtn.style.transform = ''
+      downloadBtn.style.boxShadow = '0 3px 0 #7a4040, 0 4px 12px rgba(100, 60, 60, 0.2)'
+    })
+    downloadBtn.addEventListener('mouseover', () => { downloadBtn.style.background = '#a84848' })
+    downloadBtn.addEventListener('mouseout', () => {
+      downloadBtn.style.background = MAUVE_DARK
+      downloadBtn.style.transform = ''
+      downloadBtn.style.boxShadow = '0 3px 0 #7a4040, 0 4px 12px rgba(100, 60, 60, 0.2)'
+    })
+    downloadBtn.addEventListener('click', () => this._resolve('download'))
+    btnRow.appendChild(downloadBtn)
+
+    const newBtn = this._makeBtn('New Strategy', CREAM, TEXT, `
+      flex: 1; border: 2px solid ${MAUVE_LIGHT};
+    `)
+    newBtn.addEventListener('mouseover', () => { newBtn.style.background = MAUVE_LIGHT })
+    newBtn.addEventListener('mouseout', () => { newBtn.style.background = CREAM })
+    newBtn.addEventListener('click', () => this._resolve('new'))
+    btnRow.appendChild(newBtn)
+
+    panel.appendChild(btnRow)
+
+    this.overlay.appendChild(panel)
+    parent.appendChild(this.overlay)
+  }
+
+  show(stats: CompletionStats): Promise<CompletionAction> {
+    // Update stats display
+    const playerName = stats.player === 0 ? 'Black' : 'White'
+    const playerColor = stats.player === 0 ? '#506080' : MAUVE_DARK
+    this.statsEl.innerHTML = `
+      <div style="text-align: center;">
+        <div style="font-size: 22px; font-weight: 800; color: ${playerColor};">${playerName}</div>
+        <div style="font-size: 12px; color: ${TEXT_MUTED}; font-weight: 600;">Player</div>
+      </div>
+      <div style="text-align: center;">
+        <div style="font-size: 22px; font-weight: 800; color: ${TEXT};">${stats.rows}x${stats.cols}</div>
+        <div style="font-size: 12px; color: ${TEXT_MUTED}; font-weight: 600;">Board</div>
+      </div>
+      <div style="text-align: center;">
+        <div style="font-size: 22px; font-weight: 800; color: ${GREEN};">${stats.infoStates}</div>
+        <div style="font-size: 12px; color: ${TEXT_MUTED}; font-weight: 600;">Info States</div>
+      </div>
+    `
+
+    this.overlay.style.display = 'flex'
+    return new Promise((resolve) => { this.resolve = resolve })
+  }
+
+  hide(): void {
+    this.overlay.style.display = 'none'
+    this.resolve = null
+  }
+
+  private _resolve(action: CompletionAction): void {
+    const resolve = this.resolve
+    this.hide()
+    resolve?.(action)
+  }
+
+  private _makeBtn(text: string, bg: string, fg: string, extra = ''): HTMLButtonElement {
+    const btn = document.createElement('button')
+    btn.textContent = text
+    btn.style.cssText = `
+      padding: 12px 20px; border-radius: 10px; cursor: pointer;
+      font-family: ${FONT}; font-size: 15px; font-weight: 700;
+      background: ${bg}; color: ${fg}; border: none;
+      transition: filter 0.12s, transform 0.1s;
+      ${extra}
+    `
+    return btn
+  }
+}

--- a/game/src/ui/CompletionPanel.ts
+++ b/game/src/ui/CompletionPanel.ts
@@ -26,6 +26,8 @@ export type CompletionAction = 'download' | 'new' | 'dismiss'
 export class CompletionPanel {
   private overlay: HTMLDivElement
   private statsEl: HTMLDivElement
+  private confirmEl: HTMLDivElement
+  private downloaded = false
   private resolve: ((action: CompletionAction) => void) | null = null
 
   constructor(parent: HTMLElement) {
@@ -90,7 +92,10 @@ export class CompletionPanel {
       downloadBtn.style.transform = ''
       downloadBtn.style.boxShadow = '0 3px 0 #7a4040, 0 4px 12px rgba(100, 60, 60, 0.2)'
     })
-    downloadBtn.addEventListener('click', () => this._resolve('download'))
+    downloadBtn.addEventListener('click', () => {
+      this.downloaded = true
+      this._resolve('download')
+    })
     btnRow.appendChild(downloadBtn)
 
     const newBtn = this._makeBtn('New Strategy', CREAM, TEXT, `
@@ -98,16 +103,60 @@ export class CompletionPanel {
     `)
     newBtn.addEventListener('mouseover', () => { newBtn.style.background = MAUVE_LIGHT })
     newBtn.addEventListener('mouseout', () => { newBtn.style.background = CREAM })
-    newBtn.addEventListener('click', () => this._resolve('new'))
+    newBtn.addEventListener('click', () => {
+      if (!this.downloaded) {
+        this._showConfirm()
+      } else {
+        this._resolve('new')
+      }
+    })
     btnRow.appendChild(newBtn)
 
     panel.appendChild(btnRow)
+
+    // ── Confirmation sub-panel (hidden by default) ──────────────────
+    this.confirmEl = document.createElement('div')
+    this.confirmEl.style.cssText = `
+      display: none; margin-top: 20px; padding: 16px 20px;
+      background: #fff0e0; border: 2px solid #ffd5a0; border-radius: 10px;
+      text-align: center;
+    `
+    this.confirmEl.innerHTML = `
+      <p style="margin: 0 0 12px; font-size: 15px; font-weight: 700; color: #c75000;">
+        You haven't downloaded the strategy yet.
+      </p>
+      <p style="margin: 0 0 16px; font-size: 14px; color: ${TEXT_MUTED};">
+        Starting a new strategy will discard your current work.
+      </p>
+    `
+
+    const confirmBtnRow = document.createElement('div')
+    confirmBtnRow.style.cssText = 'display: flex; gap: 10px; justify-content: center;'
+
+    const discardBtn = this._makeBtn('Discard & Start New', '#c75000', '#fff', `
+      border: none; font-weight: 800;
+    `)
+    discardBtn.addEventListener('mouseover', () => { discardBtn.style.background = '#a84400' })
+    discardBtn.addEventListener('mouseout', () => { discardBtn.style.background = '#c75000' })
+    discardBtn.addEventListener('click', () => this._resolve('new'))
+    confirmBtnRow.appendChild(discardBtn)
+
+    const goBackBtn = this._makeBtn('Go Back', CREAM, TEXT, `border: 2px solid ${MAUVE_LIGHT};`)
+    goBackBtn.addEventListener('mouseover', () => { goBackBtn.style.background = MAUVE_LIGHT })
+    goBackBtn.addEventListener('mouseout', () => { goBackBtn.style.background = CREAM })
+    goBackBtn.addEventListener('click', () => { this.confirmEl.style.display = 'none' })
+    confirmBtnRow.appendChild(goBackBtn)
+
+    this.confirmEl.appendChild(confirmBtnRow)
+    panel.appendChild(this.confirmEl)
 
     this.overlay.appendChild(panel)
     parent.appendChild(this.overlay)
   }
 
   show(stats: CompletionStats): Promise<CompletionAction> {
+    this.downloaded = false
+    this.confirmEl.style.display = 'none'
     // Update stats display
     const playerName = stats.player === 0 ? 'Black' : 'White'
     const playerColor = stats.player === 0 ? '#506080' : MAUVE_DARK
@@ -133,6 +182,10 @@ export class CompletionPanel {
   hide(): void {
     this.overlay.style.display = 'none'
     this.resolve = null
+  }
+
+  private _showConfirm(): void {
+    this.confirmEl.style.display = 'block'
   }
 
   private _resolve(action: CompletionAction): void {

--- a/game/src/ui/CompletionPanel.ts
+++ b/game/src/ui/CompletionPanel.ts
@@ -114,6 +114,19 @@ export class CompletionPanel {
 
     panel.appendChild(btnRow)
 
+    // ── Close / dismiss link ──────────────────────────────────────────
+    const closeLink = document.createElement('div')
+    closeLink.textContent = 'Keep inspecting the board'
+    closeLink.style.cssText = `
+      margin-top: 16px; font-size: 13px; font-weight: 600;
+      color: ${TEXT_MUTED}; cursor: pointer; text-decoration: underline;
+      text-underline-offset: 3px;
+    `
+    closeLink.addEventListener('mouseover', () => { closeLink.style.color = TEXT })
+    closeLink.addEventListener('mouseout', () => { closeLink.style.color = TEXT_MUTED })
+    closeLink.addEventListener('click', () => this._resolve('dismiss'))
+    panel.appendChild(closeLink)
+
     // ── Confirmation sub-panel (hidden by default) ──────────────────
     this.confirmEl = document.createElement('div')
     this.confirmEl.style.cssText = `
@@ -154,8 +167,13 @@ export class CompletionPanel {
     parent.appendChild(this.overlay)
   }
 
-  show(stats: CompletionStats): Promise<CompletionAction> {
+  /** Reset download tracking (call once when the strategy first completes). */
+  resetDownloaded(): void {
     this.downloaded = false
+  }
+
+  show(stats: CompletionStats): Promise<CompletionAction> {
+    // Don't reset downloaded here — it persists across re-shows
     this.confirmEl.style.display = 'none'
     // Update stats display
     const playerName = stats.player === 0 ? 'Black' : 'White'


### PR DESCRIPTION
## Summary

- **Completion modal**: Warm cream/green panel with stats (player, board size, info state count) instead of silent auto-download
- **Celebration chime**: Ascending C-E-G major triad on strategy completion
- **Download button**: User-initiated JSON export instead of auto-download
- **New Strategy**: Opens setup panel; warns if strategy hasn't been downloaded
- **Dismiss**: "Keep inspecting the board" link lets users close the modal and explore
- **Safety**: Escape blocked during modal, completion re-shows if setup is cancelled
- **Docs**: Added strategy investigation screen and diagram export to planned features

## Test plan
- [ ] Complete a strategy — chime plays, modal appears with stats
- [ ] Download JSON — file downloads, modal re-shows
- [ ] New Strategy after download — goes straight to setup (no warning)
- [ ] New Strategy without download — amber discard warning appears
- [ ] "Go Back" on warning — returns to completion modal
- [ ] "Discard & Start New" — opens setup panel
- [ ] Cancel setup from completion → completion modal re-appears
- [ ] "Keep inspecting the board" — modal closes, board is interactive
- [ ] Escape while modal open — blocked (no setup underneath)

🤖 Generated with [Claude Code](https://claude.com/claude-code)