### PR TITLE
feat: GPU device support for neural CFR algorithms

### DIFF
--- a/darkhex/algorithms/deep_cfr.py
+++ b/darkhex/algorithms/deep_cfr.py
@@ -25,6 +25,40 @@ def _player_index(p: Player) -> int:
     return 0 if p == Player.Black else 1
 
 
+def resolve_device(device: str) -> torch.device:
+    """Resolve device string to torch.device, with auto-detection.
+
+    Args:
+        device: One of "auto", "cpu", "cuda", "mps", or any valid torch device string.
+
+    Returns:
+        Resolved torch.device. "auto" checks CUDA → MPS → CPU.
+
+    Raises:
+        ValueError: If an explicit backend is requested but unavailable.
+    """
+    if device == "auto":
+        if torch.cuda.is_available():
+            return torch.device("cuda")
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            return torch.device("mps")
+        return torch.device("cpu")
+    if device == "cuda" and not torch.cuda.is_available():
+        raise ValueError(
+            "device='cuda' requested but CUDA is not available. "
+            "Use 'cpu' or 'auto'."
+        )
+    if device == "mps" and (
+        not hasattr(torch.backends, "mps")
+        or not torch.backends.mps.is_available()
+    ):
+        raise ValueError(
+            "device='mps' requested but MPS is not available. "
+            "Use 'cpu' or 'auto'."
+        )
+    return torch.device(device)
+
+
 def encode_info_state(info_state_str: str, rows: int, cols: int) -> torch.Tensor:
     """Convert canonical info state string to a flat tensor.
 
@@ -184,6 +218,7 @@ class DeepCFRConfig:
     num_traversals: int = 375
     seed: int = 42
     reinitialize_advantage_networks: bool = True
+    device: str = "cpu"
 
 
 class DeepCFR:
@@ -202,13 +237,14 @@ class DeepCFR:
         self._n = cfg.rows * cfg.cols
         self._input_dim = 3 * self._n + 1
         self._iteration = 0
+        self._device = resolve_device(cfg.device)
 
         torch.manual_seed(cfg.seed)
         self._rng = np.random.default_rng(cfg.seed)
 
         # One advantage net per player, one shared strategy net
         self._advantage_nets = [
-            MLP(self._input_dim, cfg.hidden_sizes, self._n)
+            MLP(self._input_dim, cfg.hidden_sizes, self._n).to(self._device)
             for _ in range(2)
         ]
         self._strategy_net = MLP(
@@ -216,7 +252,7 @@ class DeepCFR:
             cfg.hidden_sizes,
             self._n,
             final_activation=nn.Softmax(dim=-1),
-        )
+        ).to(self._device)
 
         # Reservoir buffers: one advantage buffer per player, one strategy buffer
         # Use derived seeds for deterministic replay buffer sampling.
@@ -344,7 +380,7 @@ class DeepCFR:
         with torch.no_grad():
             x = encode_info_state(
                 canonical_str, self.cfg.rows, self.cfg.cols
-            ).unsqueeze(0)
+            ).unsqueeze(0).to(self._device)
             advantages = self._advantage_nets[player](x).squeeze(0)
 
         positive = {
@@ -383,6 +419,9 @@ class DeepCFR:
             states, iterations, targets = buf.sample(
                 self.cfg.batch_size_advantage
             )
+            states = states.to(self._device)
+            iterations = iterations.to(self._device)
+            targets = targets.to(self._device)
             # LCFR weighting: sqrt(t) trick -> MSE gives t*(pred-target)^2
             weights = torch.sqrt(iterations.float()).unsqueeze(1)
             preds = net(states)
@@ -409,6 +448,9 @@ class DeepCFR:
             states, iterations, targets = buf.sample(
                 self.cfg.batch_size_strategy
             )
+            states = states.to(self._device)
+            iterations = iterations.to(self._device)
+            targets = targets.to(self._device)
             weights = torch.sqrt(iterations.float()).unsqueeze(1)
             preds = self._strategy_net(states)
             loss = F.mse_loss(weights * preds, weights * targets)
@@ -480,7 +522,7 @@ class DeepCFR:
             with torch.no_grad():
                 x = encode_info_state(
                     canonical_str, self.cfg.rows, self.cfg.cols
-                ).unsqueeze(0)
+                ).unsqueeze(0).to(self._device)
                 probs = self._strategy_net(x).squeeze(0)
 
             # Renormalize over legal actions only — the softmax output

--- a/darkhex/algorithms/dream.py
+++ b/darkhex/algorithms/dream.py
@@ -25,6 +25,7 @@ from darkhex.algorithms.deep_cfr import (
     MLP,
     ReservoirBuffer,
     encode_info_state,
+    resolve_device,
     _player_index,
 )
 
@@ -53,9 +54,11 @@ class QBaseline:
         lr: float,
         buffer_size: int,
         seed: int,
+        device: torch.device | None = None,
     ) -> None:
+        self._device = device or torch.device("cpu")
         # Input: concatenated info states of both players
-        self.net = MLP(input_dim, hidden_sizes, output_dim)
+        self.net = MLP(input_dim, hidden_sizes, output_dim).to(self._device)
         self.buffer = ReservoirBuffer(buffer_size, seed=seed)
         self.optimizer = torch.optim.Adam(self.net.parameters(), lr=lr)
         self._input_dim = input_dim
@@ -63,7 +66,7 @@ class QBaseline:
     def predict(self, joint_info_state: torch.Tensor) -> torch.Tensor:
         """Predict Q-values for all actions given joint info state."""
         with torch.no_grad():
-            return self.net(joint_info_state.unsqueeze(0)).squeeze(0)
+            return self.net(joint_info_state.unsqueeze(0).to(self._device)).squeeze(0)
 
     def train_step(
         self,
@@ -79,6 +82,8 @@ class QBaseline:
 
         for _ in range(num_steps):
             states, _, targets = self.buffer.sample(batch_size)
+            states = states.to(self._device)
+            targets = targets.to(self._device)
             preds = self.net(states)
             loss = F.mse_loss(preds, targets)
 
@@ -128,6 +133,7 @@ class DREAMConfig:
     baseline_buffer_size: int = 200_000
     baseline_train_steps: int = 500
     baseline_batch_size: int = 256
+    device: str = "cpu"
 
 
 # ---------------------------------------------------------------------------
@@ -155,20 +161,22 @@ class DREAM:
         self._n = cfg.rows * cfg.cols
         self._input_dim = 3 * self._n + 1
         self._iteration = 0
+        self._device = resolve_device(cfg.device)
 
         torch.manual_seed(cfg.seed)
         self._rng = np.random.default_rng(cfg.seed)
 
         # One advantage net per player, one shared strategy net
         self._advantage_nets = [
-            MLP(self._input_dim, cfg.hidden_sizes, self._n) for _ in range(2)
+            MLP(self._input_dim, cfg.hidden_sizes, self._n).to(self._device)
+            for _ in range(2)
         ]
         self._strategy_net = MLP(
             self._input_dim,
             cfg.hidden_sizes,
             self._n,
             final_activation=nn.Softmax(dim=-1),
-        )
+        ).to(self._device)
 
         # Reservoir buffers
         self._advantage_buffers = [
@@ -202,6 +210,7 @@ class DREAM:
                     lr=cfg.lr,
                     buffer_size=cfg.baseline_buffer_size,
                     seed=cfg.seed + 10 + p,
+                    device=self._device,
                 )
 
     @property
@@ -408,7 +417,7 @@ class DREAM:
         with torch.no_grad():
             x = encode_info_state(
                 canonical_str, self.cfg.rows, self.cfg.cols
-            ).unsqueeze(0)
+            ).unsqueeze(0).to(self._device)
             advantages = self._advantage_nets[player](x).squeeze(0)
 
         positive = {
@@ -449,6 +458,9 @@ class DREAM:
             states, iterations, targets = buf.sample(
                 self.cfg.batch_size_advantage
             )
+            states = states.to(self._device)
+            iterations = iterations.to(self._device)
+            targets = targets.to(self._device)
             weights = torch.sqrt(iterations.float()).unsqueeze(1)
             preds = net(states)
             loss = F.mse_loss(weights * preds, weights * targets)
@@ -480,6 +492,9 @@ class DREAM:
             states, iterations, raw_vals = buf.sample(
                 self.cfg.batch_size_strategy
             )
+            states = states.to(self._device)
+            iterations = iterations.to(self._device)
+            raw_vals = raw_vals.to(self._device)
             # Unpack: targets = sigma (first n columns), weights = last column
             targets = raw_vals[:, : self._n]
             strat_weights = raw_vals[:, self._n].unsqueeze(1)
@@ -563,7 +578,7 @@ class DREAM:
             with torch.no_grad():
                 x = encode_info_state(
                     canonical_str, self.cfg.rows, self.cfg.cols
-                ).unsqueeze(0)
+                ).unsqueeze(0).to(self._device)
                 probs = self._strategy_net(x).squeeze(0)
 
             # Renormalize over legal actions only

--- a/darkhex/algorithms/escher.py
+++ b/darkhex/algorithms/escher.py
@@ -25,6 +25,7 @@ from darkhex.algorithms.deep_cfr import (
     MLP,
     ReservoirBuffer,
     encode_info_state,
+    resolve_device,
     _player_index,
 )
 
@@ -67,6 +68,7 @@ class ESCHERConfig:
     num_iters: int = 100
 
     seed: int = 42
+    device: str = "cpu"
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +99,7 @@ class ESCHER:
         self._obs_dim = 3 * self._n + 1  # single-player info state
         self._history_dim = 2 * self._obs_dim  # both players' info states
         self._iteration = 0
+        self._device = resolve_device(cfg.device)
 
         torch.manual_seed(cfg.seed)
         self._rng = np.random.default_rng(cfg.seed)
@@ -104,20 +107,20 @@ class ESCHER:
         # Value networks: predict V(h) from history (per player)
         # Single scalar output — state value, not per-action
         self._value_nets = [
-            MLP(self._history_dim, cfg.value_hidden, 1)
+            MLP(self._history_dim, cfg.value_hidden, 1).to(self._device)
             for _ in range(2)
         ]
 
         # Regret networks: predict regret from info state (per player)
         self._regret_nets = [
-            MLP(self._obs_dim, cfg.regret_hidden, self._n)
+            MLP(self._obs_dim, cfg.regret_hidden, self._n).to(self._device)
             for _ in range(2)
         ]
 
         # Average policy network: shared
         self._policy_net = MLP(
             self._obs_dim, cfg.policy_hidden, self._n,
-        )
+        ).to(self._device)
 
         # Buffers
         self._value_buffers = [
@@ -307,15 +310,21 @@ class ESCHER:
         """
         actions = state.legal_actions()
         num_actions = len(actions)
-        q_values = np.zeros(num_actions, dtype=np.float64)
+
+        # Batch all child histories into a single forward pass
+        histories = []
+        for a in actions:
+            child = state.copy()
+            child.apply_action(a)
+            histories.append(self._encode_history(child))
 
         with torch.no_grad():
-            for i, a in enumerate(actions):
-                child = state.copy()
-                child.apply_action(a)
-                history = self._encode_history(child)
-                x = torch.from_numpy(history).float().unsqueeze(0)
-                q_values[i] = self._value_nets[player](x).item()
+            batch = torch.from_numpy(
+                np.stack(histories)
+            ).float().to(self._device)
+            q_values = (
+                self._value_nets[player](batch).squeeze(-1).cpu().numpy()
+            ).astype(np.float64)
 
         value = np.sum(policy * q_values)
         return q_values - value
@@ -336,6 +345,8 @@ class ESCHER:
 
         for _ in range(self.cfg.value_train_steps):
             states, _, targets = buf.sample(self.cfg.value_batch_size)
+            states = states.to(self._device)
+            targets = targets.to(self._device)
             preds = net(states)
             loss = F.mse_loss(preds, targets)
 
@@ -363,6 +374,9 @@ class ESCHER:
             states, iterations, combined = buf.sample(
                 self.cfg.regret_batch_size
             )
+            states = states.to(self._device)
+            iterations = iterations.to(self._device)
+            combined = combined.to(self._device)
             # Unpack: [regret_0..n-1, mask_0..n-1]
             targets = combined[:, :self._n]
             masks = combined[:, self._n:]
@@ -400,6 +414,9 @@ class ESCHER:
             states, iterations, targets = buf.sample(
                 self.cfg.policy_batch_size
             )
+            states = states.to(self._device)
+            iterations = iterations.to(self._device)
+            targets = targets.to(self._device)
             # LCFR: t / T
             weights = (iterations.float() / self._iteration).unsqueeze(1)
 
@@ -430,7 +447,7 @@ class ESCHER:
         with torch.no_grad():
             x = encode_info_state(
                 canonical_str, self.cfg.rows, self.cfg.cols
-            ).unsqueeze(0)
+            ).unsqueeze(0).to(self._device)
             regrets = self._regret_nets[player](x).squeeze(0)
 
         positive = {
@@ -506,11 +523,13 @@ class ESCHER:
             with torch.no_grad():
                 x = encode_info_state(
                     canonical_str, self.cfg.rows, self.cfg.cols
-                ).unsqueeze(0)
+                ).unsqueeze(0).to(self._device)
                 logits = self._policy_net(x).squeeze(0)
 
                 # Softmax over legal actions only
-                legal_logits = torch.full((self._n,), float('-inf'))
+                legal_logits = torch.full(
+                    (self._n,), float('-inf'), device=self._device
+                )
                 for ca in canonical_actions:
                     legal_logits[ca] = logits[ca]
                 probs = F.softmax(legal_logits, dim=0)

--- a/experiments/exp004_deep_cfr_prototype.py
+++ b/experiments/exp004_deep_cfr_prototype.py
@@ -23,7 +23,7 @@ import sys
 import time
 from pathlib import Path
 
-from darkhex.algorithms.deep_cfr import DeepCFR, DeepCFRConfig
+from darkhex.algorithms.deep_cfr import DeepCFR, DeepCFRConfig, resolve_device
 
 RESULTS_DIR = Path("results/exp004_deep_cfr")
 
@@ -118,6 +118,7 @@ def run_experiment(
     num_cfr_iters: int,
     num_traversals: int | None,
     seed: int,
+    device: str = "auto",
 ) -> None:
     board_cfg = dict(CONFIGS[board])  # copy to avoid mutating module-level default
     if num_traversals is not None:
@@ -126,11 +127,13 @@ def run_experiment(
     cfg = DeepCFRConfig(
         num_cfr_iters=1,  # we iterate manually
         seed=seed,
+        device=device,
         **board_cfg,
     )
 
     print(f"=== EXP-004: Deep CFR on {board} CDH ===")
     print(f"Config: rows={cfg.rows} cols={cfg.cols} seed={cfg.seed}")
+    print(f"  device={resolve_device(device)}")
     print(f"  hidden_sizes={cfg.hidden_sizes}")
     print(f"  traversals/iter={cfg.num_traversals}")
     print(f"  advantage_steps={cfg.advantage_train_steps}")
@@ -207,6 +210,7 @@ def run_experiment(
             "buffer_size": cfg.buffer_size,
             "num_cfr_iters": num_cfr_iters,
             "seed": cfg.seed,
+            "device": str(resolve_device(device)),
         },
         "total_time_s": round(cumulative_time, 1),
         "final_exploitability": records[-1]["exploitability"] if records else None,
@@ -276,6 +280,10 @@ def main() -> None:
         help="Traversals per player per CFR iteration",
     )
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--device", type=str, default="auto",
+        help="Torch device: auto, cpu, cuda, mps (default: auto)",
+    )
     args = parser.parse_args()
 
     default_iters = {"2x2": 100, "3x2": 50, "3x3": 30, "4x3": 200}
@@ -285,7 +293,7 @@ def main() -> None:
     if args.board != "2x2":
         sanity_check_2x2()
 
-    run_experiment(args.board, num_iters, args.traversals, args.seed)
+    run_experiment(args.board, num_iters, args.traversals, args.seed, args.device)
 
 
 if __name__ == "__main__":

--- a/experiments/exp005_dream.py
+++ b/experiments/exp005_dream.py
@@ -18,11 +18,12 @@ import time
 from pathlib import Path
 
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
+from darkhex.algorithms.deep_cfr import resolve_device
 from darkhex.algorithms.dream import DREAM, DREAMConfig
-
 
 # ---------------------------------------------------------------------------
 # Per-board configurations
@@ -84,13 +85,14 @@ def run_experiment(
     board: str,
     use_baseline: bool = False,
     seed: int = 42,
+    device: str = "auto",
 ) -> list[dict]:
     """Run DREAM on the given board size and collect convergence data."""
 
     if board not in CONFIGS:
         raise ValueError(f"Unknown board: {board}. Choose from {list(CONFIGS)}")
 
-    params = {**CONFIGS[board], "seed": seed}
+    params = {**CONFIGS[board], "seed": seed, "device": device}
     if use_baseline:
         params.update(BASELINE_OVERRIDES)
 
@@ -106,6 +108,7 @@ def run_experiment(
     print(f"  epsilon: {cfg.epsilon}")
     print(f"  reinit_every: {cfg.reinit_every}")
     print(f"  baseline: {cfg.use_baseline}")
+    print(f"  device: {resolve_device(device)}")
     print(f"{'='*60}\n")
 
     total_time = 0.0
@@ -238,12 +241,16 @@ def main():
         help="Enable Q-baseline for variance reduction",
     )
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--device", type=str, default="auto",
+        help="Torch device: auto, cpu, cuda, mps (default: auto)",
+    )
     args = parser.parse_args()
 
     condition = "dream_bl" if args.baseline else "dream"
     output_dir = Path(f"results/exp005_dream/{args.board}_{condition}")
 
-    records = run_experiment(args.board, args.baseline, args.seed)
+    records = run_experiment(args.board, args.baseline, args.seed, args.device)
     save_results(records, output_dir, args.board)
 
 

--- a/tests/test_deep_cfr.py
+++ b/tests/test_deep_cfr.py
@@ -14,6 +14,7 @@ from darkhex.algorithms.deep_cfr import (  # noqa: E402
     MLP,
     ReservoirBuffer,
     encode_info_state,
+    resolve_device,
 )  # noqa: I001
 
 
@@ -318,3 +319,57 @@ class TestDeepCFRIntegration:
         assert expl_50 < expl_10 + 0.1, (
             f"Exploitability didn't decrease: {expl_10:.4f} -> {expl_50:.4f}"
         )
+
+
+# ── Device placement tests ───────────────────────────────────────────────
+
+
+class TestDevicePlacement:
+    def test_resolve_device_cpu(self):
+        assert resolve_device("cpu") == torch.device("cpu")
+
+    def test_resolve_device_auto(self):
+        dev = resolve_device("auto")
+        assert isinstance(dev, torch.device)
+
+    def test_resolve_device_rejects_unavailable_cuda(self):
+        if torch.cuda.is_available():
+            pytest.skip("CUDA is available on this machine")
+        with pytest.raises(ValueError, match="CUDA is not available"):
+            resolve_device("cuda")
+
+    def test_resolve_device_rejects_unavailable_mps(self):
+        mps_available = (
+            hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+        )
+        if mps_available:
+            pytest.skip("MPS is available on this machine")
+        with pytest.raises(ValueError, match="MPS is not available"):
+            resolve_device("mps")
+
+    def test_nets_on_device(self):
+        """All networks should be on the resolved device after init."""
+        cfg = DeepCFRConfig(rows=2, cols=2, device="cpu")
+        solver = DeepCFR(cfg)
+        for net in solver._advantage_nets:
+            for p in net.parameters():
+                assert p.device == torch.device("cpu")
+        for p in solver._strategy_net.parameters():
+            assert p.device == torch.device("cpu")
+
+    def test_2x2_runs_with_explicit_cpu(self):
+        """Deep CFR with explicit device='cpu' works end-to-end."""
+        cfg = DeepCFRConfig(
+            rows=2, cols=2,
+            hidden_sizes=(32,),
+            num_cfr_iters=3,
+            num_traversals=10,
+            advantage_train_steps=10,
+            strategy_train_steps=10,
+            buffer_size=1000,
+            device="cpu",
+        )
+        solver = DeepCFR(cfg)
+        solver.solve()
+        expl = solver.exploitability()
+        assert 0.0 <= expl <= 2.0

--- a/tests/test_dream.py
+++ b/tests/test_dream.py
@@ -7,6 +7,7 @@ torch = pytest.importorskip("torch")
 nn = torch.nn
 
 from darkhex._engine import DarkHexState, Player  # noqa: E402
+
 from darkhex.algorithms.deep_cfr import (  # noqa: E402
     MLP,
     ReservoirBuffer,
@@ -17,7 +18,6 @@ from darkhex.algorithms.dream import (  # noqa: E402
     DREAMConfig,
     QBaseline,
 )
-
 
 # ── Shared component tests (verify imports work) ─────────────────────────
 
@@ -338,3 +338,66 @@ class TestDREAMIntegration:
         assert expl_50 < expl_10 + 0.1, (
             f"Exploitability didn't decrease: {expl_10:.4f} -> {expl_50:.4f}"
         )
+
+
+# ── Device placement tests ───────────────────────────────────────────────
+
+
+class TestDevicePlacement:
+    def test_dream_nets_on_device(self):
+        cfg = DREAMConfig(rows=2, cols=2, device="cpu")
+        solver = DREAM(cfg)
+        for net in solver._advantage_nets:
+            for p in net.parameters():
+                assert p.device == torch.device("cpu")
+        for p in solver._strategy_net.parameters():
+            assert p.device == torch.device("cpu")
+
+    def test_baseline_nets_on_device(self):
+        cfg = DREAMConfig(
+            rows=2, cols=2, use_baseline=True, device="cpu",
+        )
+        solver = DREAM(cfg)
+        for bl in solver._baselines:
+            assert bl is not None
+            for p in bl.net.parameters():
+                assert p.device == torch.device("cpu")
+
+    def test_2x2_runs_with_explicit_cpu(self):
+        cfg = DREAMConfig(
+            rows=2, cols=2,
+            hidden_sizes=(32,),
+            num_cfr_iters=3,
+            num_traversals=50,
+            advantage_train_steps=10,
+            strategy_train_steps=10,
+            buffer_size=1000,
+            reinit_every=2,
+            device="cpu",
+        )
+        solver = DREAM(cfg)
+        solver.solve()
+        expl = solver.exploitability()
+        assert 0.0 <= expl <= 2.0
+
+    def test_2x2_baseline_with_explicit_cpu(self):
+        cfg = DREAMConfig(
+            rows=2, cols=2,
+            hidden_sizes=(32,),
+            num_cfr_iters=3,
+            num_traversals=50,
+            advantage_train_steps=10,
+            strategy_train_steps=10,
+            buffer_size=1000,
+            reinit_every=2,
+            use_baseline=True,
+            baseline_hidden_sizes=(32,),
+            baseline_buffer_size=500,
+            baseline_train_steps=10,
+            baseline_batch_size=16,
+            device="cpu",
+        )
+        solver = DREAM(cfg)
+        solver.solve()
+        expl = solver.exploitability()
+        assert 0.0 <= expl <= 2.0

--- a/tests/test_escher.py
+++ b/tests/test_escher.py
@@ -1,0 +1,100 @@
+"""Tests for ESCHER implementation."""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from darkhex._engine import DarkHexState  # noqa: E402
+
+from darkhex.algorithms.escher import ESCHER, ESCHERConfig  # noqa: E402
+
+# ── Config tests ──────────────────────────────────────────────────────────
+
+
+class TestESCHERConfig:
+    def test_default_config(self):
+        cfg = ESCHERConfig(rows=2, cols=2)
+        assert cfg.num_iters == 100
+        assert cfg.value_exploration == 0.1
+        assert cfg.device == "cpu"
+
+    def test_explicit_device(self):
+        cfg = ESCHERConfig(rows=2, cols=2, device="cpu")
+        assert cfg.device == "cpu"
+
+
+# ── Device placement tests ───────────────────────────────────────────────
+
+
+class TestDevicePlacement:
+    def test_all_nets_on_device(self):
+        cfg = ESCHERConfig(rows=2, cols=2, device="cpu")
+        solver = ESCHER(cfg)
+        for net in solver._value_nets:
+            for p in net.parameters():
+                assert p.device == torch.device("cpu")
+        for net in solver._regret_nets:
+            for p in net.parameters():
+                assert p.device == torch.device("cpu")
+        for p in solver._policy_net.parameters():
+            assert p.device == torch.device("cpu")
+
+
+# ── Integration tests ────────────────────────────────────────────────────
+
+
+class TestESCHERIntegration:
+    def _make_small_solver(self, **overrides):
+        defaults = dict(
+            rows=2, cols=2,
+            value_hidden=(32,),
+            regret_hidden=(32,),
+            policy_hidden=(32,),
+            value_buffer_size=1000,
+            regret_buffer_size=1000,
+            policy_buffer_size=1000,
+            value_batch_size=16,
+            value_train_steps=10,
+            regret_batch_size=16,
+            regret_train_steps=10,
+            policy_batch_size=16,
+            policy_train_steps=10,
+            value_traversals=20,
+            regret_traversals=20,
+            num_iters=3,
+            device="cpu",
+        )
+        defaults.update(overrides)
+        cfg = ESCHERConfig(**defaults)
+        return ESCHER(cfg)
+
+    def test_2x2_runs_without_error(self):
+        solver = self._make_small_solver()
+        solver.solve()
+        assert solver.iteration == 3
+
+    def test_2x2_strategy_valid(self):
+        solver = self._make_small_solver(num_iters=5)
+        solver.solve()
+        strategy = solver.extract_strategy()
+        assert len(strategy) > 0
+        for info_state, action_probs in strategy.items():
+            assert len(action_probs) > 0
+            total = sum(p for _, p in action_probs)
+            assert total > 0.5, f"Strategy at {info_state} sums to {total}"
+
+    def test_2x2_exploitability_computable(self):
+        solver = self._make_small_solver(num_iters=5)
+        solver.solve()
+        expl = solver.exploitability()
+        assert 0.0 <= expl <= 2.0
+
+    def test_compute_regret_returns_finite(self):
+        solver = self._make_small_solver()
+        state = DarkHexState(2, 2)
+        actions = state.legal_actions()
+        policy = np.ones(len(actions), dtype=np.float64) / len(actions)
+        regret = solver._compute_regret(state, policy, 0)
+        assert np.all(np.isfinite(regret))
+        assert len(regret) == len(actions)


### PR DESCRIPTION
## Summary
- Add configurable device placement (CPU/CUDA/MPS) to Deep CFR, DREAM, and ESCHER via `resolve_device()` with auto-detection and explicit backend validation
- Default remains `cpu` for reproducibility; users opt into GPU with `--device cuda/mps`
- Batch ESCHER `_compute_regret` for N→1 GPU round-trips instead of per-action sequential calls
- Add `--device` CLI arg to exp004/exp005 experiment scripts
- Add device placement tests + new `test_escher.py`

## Test plan
- [x] All existing tests pass (`make check` — ruff, cargo test, pytest)
- [x] New device placement tests for all three algorithms
- [x] Backend validation tests (rejects unavailable CUDA/MPS with clear error)
- [x] ESCHER integration tests (config, solve, strategy extraction, exploitability)
- [ ] Manual GPU smoke test on CUDA/MPS machine with `--device cuda`/`--device mps`