### PR TITLE
feat(game): strategy investigation screen with interactive tree diagram

### DIFF
--- a/game/src/investigation/InvestigationView.ts
+++ b/game/src/investigation/InvestigationView.ts
@@ -1,0 +1,272 @@
+import type { Policy, StrategyConfig } from '../strategy/types'
+import type { InfoStateOps } from '../engine/InfoStateOps'
+import type { TreeNode } from './types'
+import { buildTree, cellLabel } from './TreeBuilder'
+import { DEFAULT_LAYOUT } from './TreeLayout'
+import { TreeRenderer } from './TreeRenderer'
+import { drawMiniBoard, miniBoardSize } from './MiniBoard'
+
+const FONT = "'Nunito', -apple-system, BlinkMacSystemFont, sans-serif"
+const CREAM = '#faf5ef'
+const MAUVE_DARK = '#995a5a'
+const MAUVE_LIGHT = '#e8d5d5'
+const TEXT = '#4a3535'
+const TEXT_MUTED = '#8a7070'
+const GREEN = '#5a9a5e'
+const SIDEBAR_WIDTH = 280
+
+/**
+ * Full-screen investigation overlay.
+ * Composes TreeRenderer (canvas) + detail sidebar + bottom bar.
+ */
+export class InvestigationView {
+  private parent: HTMLElement
+  private overlay: HTMLDivElement | null = null
+  private renderer: TreeRenderer | null = null
+  private detailEl: HTMLDivElement | null = null
+  private _onKeyDown: ((e: KeyboardEvent) => void) | null = null
+
+  private root: TreeNode | null = null
+  private rows = 0
+  private cols = 0
+
+  constructor(parent: HTMLElement) {
+    this.parent = parent
+  }
+
+  async run(policy: Policy, config: StrategyConfig, infoOps: InfoStateOps): Promise<void> {
+    this.rows = config.rows
+    this.cols = config.cols
+
+    // Build tree
+    this.root = buildTree(policy, infoOps, config)
+
+    // Create overlay
+    this.overlay = document.createElement('div')
+    this.overlay.style.cssText = `
+      position: fixed; top: 0; left: 0; width: 100%; height: 100%;
+      background: ${CREAM}; z-index: 90; display: flex; flex-direction: column;
+      font-family: ${FONT}; color: ${TEXT};
+    `
+
+    // ── Top bar ─────────────────────────────────────────────────────
+    const topBar = document.createElement('div')
+    topBar.style.cssText = `
+      display: flex; align-items: center; gap: 12px; padding: 10px 16px;
+      border-bottom: 1px solid ${MAUVE_LIGHT}; flex-shrink: 0;
+      background: ${CREAM};
+    `
+
+    const escBadge = document.createElement('span')
+    escBadge.textContent = 'Esc = menu'
+    escBadge.style.cssText = `
+      font-size: 12px; font-weight: 700; color: ${TEXT_MUTED};
+      background: ${MAUVE_LIGHT}; padding: 4px 10px; border-radius: 6px;
+    `
+    topBar.appendChild(escBadge)
+
+    const fitBtn = this._makeBtn('Fit to View', MAUVE_LIGHT, TEXT)
+    fitBtn.addEventListener('click', () => this.renderer?.fitToView())
+    topBar.appendChild(fitBtn)
+
+    const spacer = document.createElement('div')
+    spacer.style.flex = '1'
+    topBar.appendChild(spacer)
+
+    const playerName = config.player === 0 ? 'Black' : 'White'
+    const playerColor = config.player === 0 ? '#506080' : MAUVE_DARK
+    const summary = document.createElement('span')
+    summary.style.cssText = `font-size: 14px; font-weight: 700; color: ${TEXT_MUTED};`
+    summary.innerHTML = `
+      <span style="color: ${playerColor}; font-weight: 800;">${playerName}</span>
+      &nbsp;${config.rows}x${config.cols}
+      &nbsp;&middot;&nbsp;${policy.size} info states
+    `
+    topBar.appendChild(summary)
+
+    this.overlay.appendChild(topBar)
+
+    // ── Main area: canvas + sidebar ─────────────────────────────────
+    const main = document.createElement('div')
+    main.style.cssText = 'display: flex; flex: 1; overflow: hidden;'
+
+    const canvasWrap = document.createElement('div')
+    canvasWrap.style.cssText = 'flex: 1; position: relative; overflow: hidden;'
+
+    const canvas = document.createElement('canvas')
+    canvas.style.cssText = 'width: 100%; height: 100%; display: block;'
+    canvasWrap.appendChild(canvas)
+    main.appendChild(canvasWrap)
+
+    // Detail sidebar
+    this.detailEl = document.createElement('div')
+    this.detailEl.style.cssText = `
+      width: ${SIDEBAR_WIDTH}px; flex-shrink: 0; overflow-y: auto;
+      border-left: 1px solid ${MAUVE_LIGHT}; padding: 16px;
+      display: none; flex-direction: column; gap: 12px;
+      background: #fff;
+    `
+    main.appendChild(this.detailEl)
+
+    this.overlay.appendChild(main)
+    this.parent.appendChild(this.overlay)
+
+    // ── Create renderer ─────────────────────────────────────────────
+    this.renderer = new TreeRenderer(
+      canvas, this.root, config.rows, config.cols, DEFAULT_LAYOUT,
+      {
+        onNodeClick: (node) => this._showDetail(node, config),
+        onNodeDoubleClick: (node) => this._toggleCollapse(node),
+      },
+    )
+    this.renderer.fitToView()
+
+    // ── Keyboard ────────────────────────────────────────────────────
+    return new Promise<void>((resolve) => {
+      this._onKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          resolve()
+        }
+      }
+      window.addEventListener('keydown', this._onKeyDown)
+    })
+  }
+
+  dispose(): void {
+    if (this._onKeyDown) window.removeEventListener('keydown', this._onKeyDown)
+    this.renderer?.dispose()
+    this.overlay?.remove()
+    this.overlay = null
+    this.renderer = null
+  }
+
+  // ── Detail sidebar ──────────────────────────────────────────────────────────
+
+  private _showDetail(node: TreeNode, config: StrategyConfig): void {
+    if (!this.detailEl) return
+    this.renderer?.selectNode(node)
+    this.detailEl.style.display = 'flex'
+    this.detailEl.innerHTML = ''
+
+    // Enlarged mini board
+    const boardCanvas = document.createElement('canvas')
+    const detailCellSize = 14
+    const { w, h } = miniBoardSize(this.rows, this.cols, detailCellSize)
+    const pad = 16
+    boardCanvas.width = (w + pad) * 2
+    boardCanvas.height = (h + pad) * 2
+    boardCanvas.style.cssText = `width: ${w + pad}px; height: ${h + pad}px; display: block; margin: 0 auto;`
+    const bctx = boardCanvas.getContext('2d')!
+    bctx.scale(2, 2) // retina
+    drawMiniBoard(
+      bctx,
+      (w + pad) / 2,
+      (h + pad) / 2,
+      node.boardView,
+      this.rows,
+      this.cols,
+      detailCellSize,
+      node.actions.length > 0
+        ? { highlightActions: node.actions.map(([a]) => a) }
+        : undefined,
+    )
+    this.detailEl.appendChild(boardCanvas)
+
+    // Info state string
+    const infoLabel = document.createElement('div')
+    infoLabel.style.cssText = `font-size: 11px; font-weight: 700; color: ${TEXT_MUTED}; text-transform: uppercase; letter-spacing: 0.5px;`
+    infoLabel.textContent = 'Info State'
+    this.detailEl.appendChild(infoLabel)
+
+    const infoStr = document.createElement('pre')
+    infoStr.textContent = node.infoState
+    infoStr.style.cssText = `
+      font-size: 13px; font-family: 'SF Mono', 'Fira Code', monospace;
+      background: ${CREAM}; border: 1px solid ${MAUVE_LIGHT}; border-radius: 6px;
+      padding: 8px 10px; margin: 0; overflow-x: auto; white-space: pre;
+      color: ${TEXT};
+    `
+    this.detailEl.appendChild(infoStr)
+
+    // Actions table
+    if (node.actions.length > 0) {
+      const actLabel = document.createElement('div')
+      actLabel.style.cssText = `font-size: 11px; font-weight: 700; color: ${TEXT_MUTED}; text-transform: uppercase; letter-spacing: 0.5px;`
+      actLabel.textContent = 'Actions'
+      this.detailEl.appendChild(actLabel)
+
+      const table = document.createElement('div')
+      table.style.cssText = `display: flex; flex-direction: column; gap: 4px;`
+      for (const [action, prob] of node.actions) {
+        const row = document.createElement('div')
+        row.style.cssText = `
+          display: flex; justify-content: space-between; align-items: center;
+          padding: 6px 10px; background: ${CREAM}; border-radius: 6px;
+          font-size: 14px;
+        `
+        const name = document.createElement('span')
+        name.style.cssText = `font-weight: 700; color: ${GREEN};`
+        name.textContent = cellLabel(action, config.cols)
+        const val = document.createElement('span')
+        val.style.cssText = `font-weight: 600; color: ${TEXT};`
+        val.textContent = prob.toFixed(3)
+        row.appendChild(name)
+        row.appendChild(val)
+        table.appendChild(row)
+      }
+      this.detailEl.appendChild(table)
+    }
+
+    // Metadata
+    const metaLabel = document.createElement('div')
+    metaLabel.style.cssText = `font-size: 11px; font-weight: 700; color: ${TEXT_MUTED}; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 4px;`
+    metaLabel.textContent = 'Details'
+    this.detailEl.appendChild(metaLabel)
+
+    const meta = document.createElement('div')
+    meta.style.cssText = `font-size: 13px; color: ${TEXT_MUTED}; line-height: 1.6;`
+    const items = [
+      `Depth: ${node.depth}`,
+      `Children: ${node.children.length}`,
+      `Subtree: ${node.subtreeSize} nodes`,
+      node.isTerminal ? `Terminal` : null,
+    ].filter(Boolean)
+    meta.textContent = items.join(' \u00B7 ')
+    this.detailEl.appendChild(meta)
+
+    // Expand/Collapse button (if node has children)
+    if (node.children.length > 0) {
+      const toggleBtn = this._makeBtn(
+        node.collapsed ? 'Expand Subtree' : 'Collapse Subtree',
+        MAUVE_LIGHT,
+        TEXT,
+      )
+      toggleBtn.style.marginTop = '8px'
+      toggleBtn.addEventListener('click', () => {
+        this._toggleCollapse(node)
+        this._showDetail(node, config) // refresh
+      })
+      this.detailEl.appendChild(toggleBtn)
+    }
+  }
+
+  private _toggleCollapse(node: TreeNode): void {
+    if (node.children.length === 0) return
+    node.collapsed = !node.collapsed
+    this.renderer?.relayout()
+  }
+
+  private _makeBtn(text: string, bg: string, fg: string): HTMLButtonElement {
+    const btn = document.createElement('button')
+    btn.textContent = text
+    btn.style.cssText = `
+      padding: 8px 14px; border-radius: 8px; cursor: pointer;
+      font-family: ${FONT}; font-size: 13px; font-weight: 700;
+      background: ${bg}; color: ${fg}; border: 1px solid ${MAUVE_LIGHT};
+      transition: filter 0.12s;
+    `
+    btn.addEventListener('mouseover', () => { btn.style.filter = 'brightness(0.94)' })
+    btn.addEventListener('mouseout', () => { btn.style.filter = '' })
+    return btn
+  }
+}

--- a/game/src/investigation/MiniBoard.ts
+++ b/game/src/investigation/MiniBoard.ts
@@ -1,0 +1,186 @@
+/**
+ * Draw miniature pointy-top hex boards on a Canvas 2D context.
+ * Uses the thesis-style parallelogram layout where rows shift right,
+ * with colored border edges indicating player connection sides.
+ *
+ * Orientation:
+ *   - Pointy-top hexagons (vertex at top, standard for Hex papers)
+ *   - Rows stack vertically, each row offset half a cell to the right
+ *   - Black connects North (top) ↔ South (bottom)
+ *   - White connects West (left) ↔ East (right)
+ *
+ * Pointy-top vertex numbering (v0 = top, clockwise):
+ *   v0 = top          (0, -r)
+ *   v1 = upper-right  (+√3/2 r, -r/2)
+ *   v2 = lower-right  (+√3/2 r, +r/2)
+ *   v3 = bottom       (0, +r)
+ *   v4 = lower-left   (-√3/2 r, +r/2)
+ *   v5 = upper-left   (-√3/2 r, -r/2)
+ */
+
+const COLORS = {
+  empty:     '#e0b8b8',
+  black:     '#506080',
+  white:     '#e8e0d8',
+  highlight: '#81c784',
+  outline:   '#2a2a30',
+  edgeBlack: '#506080',
+  edgeWhite: '#c8beb4',  // slightly darker cream for visibility on light bg
+}
+
+const SQRT3 = Math.sqrt(3)
+
+/**
+ * Grid (row, col) → 2D pixel offset for pointy-top hex.
+ * Rows stack vertically; each row shifts half a hex-width right.
+ */
+function hexCenter(row: number, col: number, r: number): [number, number] {
+  const x = SQRT3 * r * col + (SQRT3 / 2) * r * row
+  const y = 1.5 * r * row
+  return [x, y]
+}
+
+/** Vertex position of pointy-top hex. i=0 is top, clockwise. */
+function vtx(cx: number, cy: number, r: number, i: number): [number, number] {
+  const angle = -Math.PI / 2 + (Math.PI / 3) * i
+  return [cx + r * Math.cos(angle), cy + r * Math.sin(angle)]
+}
+
+/** Draw a single pointy-top hexagon path. */
+function hexPath(ctx: CanvasRenderingContext2D, cx: number, cy: number, r: number): void {
+  ctx.beginPath()
+  for (let i = 0; i < 6; i++) {
+    const [px, py] = vtx(cx, cy, r, i)
+    if (i === 0) ctx.moveTo(px, py)
+    else ctx.lineTo(px, py)
+  }
+  ctx.closePath()
+}
+
+export interface MiniBoardOptions {
+  highlightActions?: number[]
+}
+
+/**
+ * Draw a miniature pointy-top hex board centered at (cx, cy).
+ */
+export function drawMiniBoard(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  boardView: Int8Array,
+  rows: number,
+  cols: number,
+  cellSize: number,
+  options?: MiniBoardOptions,
+): void {
+  const highlightSet = options?.highlightActions
+    ? new Set(options.highlightActions)
+    : null
+
+  const r = cellSize * 0.92 // slightly smaller than full cell for gaps
+
+  // Center the board at (cx, cy)
+  const [firstX, firstY] = hexCenter(0, 0, cellSize)
+  const [lastX, lastY] = hexCenter(rows - 1, cols - 1, cellSize)
+  const ox = cx - (firstX + lastX) / 2
+  const oy = cy - (firstY + lastY) / 2
+
+  // Draw hex cells
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const idx = row * cols + col
+      const [hx, hy] = hexCenter(row, col, cellSize)
+      const px = hx + ox
+      const py = hy + oy
+
+      const cell = boardView[idx]
+      let fill: string
+      if (highlightSet?.has(idx)) {
+        fill = COLORS.highlight
+      } else if (cell === 1) {
+        fill = COLORS.black
+      } else if (cell === 2) {
+        fill = COLORS.white
+      } else {
+        fill = COLORS.empty
+      }
+
+      hexPath(ctx, px, py, r)
+      ctx.fillStyle = fill
+      ctx.fill()
+      ctx.strokeStyle = COLORS.outline
+      ctx.lineWidth = Math.max(0.5, cellSize * 0.08)
+      ctx.stroke()
+    }
+  }
+
+  // Draw border edges
+  const lw = Math.max(1.5, cellSize * 0.25)
+
+  // North border (row 0): Black — upper-left (v5) → top (v0) → upper-right (v1)
+  ctx.strokeStyle = COLORS.edgeBlack
+  ctx.lineWidth = lw
+  ctx.beginPath()
+  for (let col = 0; col < cols; col++) {
+    const [hx, hy] = hexCenter(0, col, cellSize)
+    const px = hx + ox, py = hy + oy
+    const [x5, y5] = vtx(px, py, r, 5)
+    const [x0, y0] = vtx(px, py, r, 0)
+    const [x1, y1] = vtx(px, py, r, 1)
+    ctx.moveTo(x5, y5)
+    ctx.lineTo(x0, y0)
+    ctx.lineTo(x1, y1)
+  }
+  ctx.stroke()
+
+  // South border (last row): Black — lower-right (v2) → bottom (v3) → lower-left (v4)
+  ctx.beginPath()
+  for (let col = 0; col < cols; col++) {
+    const [hx, hy] = hexCenter(rows - 1, col, cellSize)
+    const px = hx + ox, py = hy + oy
+    const [x2, y2] = vtx(px, py, r, 2)
+    const [x3, y3] = vtx(px, py, r, 3)
+    const [x4, y4] = vtx(px, py, r, 4)
+    ctx.moveTo(x2, y2)
+    ctx.lineTo(x3, y3)
+    ctx.lineTo(x4, y4)
+  }
+  ctx.stroke()
+
+  // West border (col 0): White — upper-left (v5) → lower-left (v4)
+  ctx.strokeStyle = COLORS.edgeWhite
+  ctx.beginPath()
+  for (let row = 0; row < rows; row++) {
+    const [hx, hy] = hexCenter(row, 0, cellSize)
+    const px = hx + ox, py = hy + oy
+    const [x5, y5] = vtx(px, py, r, 5)
+    const [x4, y4] = vtx(px, py, r, 4)
+    ctx.moveTo(x5, y5)
+    ctx.lineTo(x4, y4)
+  }
+  ctx.stroke()
+
+  // East border (last col): White — upper-right (v1) → lower-right (v2)
+  ctx.beginPath()
+  for (let row = 0; row < rows; row++) {
+    const [hx, hy] = hexCenter(row, cols - 1, cellSize)
+    const px = hx + ox, py = hy + oy
+    const [x1, y1] = vtx(px, py, r, 1)
+    const [x2, y2] = vtx(px, py, r, 2)
+    ctx.moveTo(x1, y1)
+    ctx.lineTo(x2, y2)
+  }
+  ctx.stroke()
+}
+
+/** Compute bounding box size of a mini board at given cell size. */
+export function miniBoardSize(rows: number, cols: number, cellSize: number): { w: number; h: number } {
+  if (rows === 0 || cols === 0) return { w: 0, h: 0 }
+  const [x0, y0] = hexCenter(0, 0, cellSize)
+  const [x1, y1] = hexCenter(rows - 1, cols - 1, cellSize)
+  return {
+    w: Math.abs(x1 - x0) + cellSize * SQRT3,
+    h: Math.abs(y1 - y0) + cellSize * 2,
+  }
+}

--- a/game/src/investigation/TreeBuilder.ts
+++ b/game/src/investigation/TreeBuilder.ts
@@ -1,0 +1,130 @@
+import type { InfoStateOps } from '../engine/InfoStateOps'
+import type { Policy, StrategyConfig } from '../strategy/types'
+import type { TreeNode } from './types'
+
+const DEFAULT_COLLAPSE_DEPTH = 3
+
+/** Cell index → human-readable label: col letter (a-z) + row (1-based). */
+export function cellLabel(index: number, cols: number): string {
+  const row = Math.floor(index / cols)
+  const col = index % cols
+  return String.fromCharCode(97 + col) + (row + 1)
+}
+
+/**
+ * Build the game tree from a completed policy.
+ *
+ * Walks the policy starting from the initial info state, creating a TreeNode
+ * for each reachable state. Collision-possible actions produce two children:
+ * one for placement (stonePlayer = policy player) and one for collision
+ * (stonePlayer = opponent, edge marked isCollision).
+ *
+ * Terminal info states become leaf nodes with no actions.
+ * Info states not in the policy (but reachable) also become leaf nodes.
+ *
+ * Memoizes by info state: when the same info state is reached via multiple
+ * paths, subsequent occurrences reuse the first-built node (shared subtree).
+ * This prevents exponential blowup from transpositions in realistic policies.
+ */
+export function buildTree(
+  policy: Policy,
+  infoOps: InfoStateOps,
+  config: StrategyConfig,
+): TreeNode {
+  let nextId = 0
+  const memo = new Map<string, TreeNode>() // infoState → already-built node
+
+  function build(infoState: string, depth: number): TreeNode {
+    // Reuse memoized node for transpositions (shared info states via different paths)
+    const existing = memo.get(infoState)
+    if (existing) return existing
+
+    const id = nextId++
+    const boardView = infoOps.boardViewFlat(infoState)
+    const isTerminal = infoOps.isTerminal(infoState)
+    const actions = policy.get(infoState) ?? []
+
+    const node: TreeNode = {
+      id,
+      infoState,
+      boardView,
+      actions,
+      children: [],
+      depth,
+      isTerminal,
+      x: 0,
+      y: 0,
+      collapsed: depth >= DEFAULT_COLLAPSE_DEPTH,
+      subtreeSize: 0,
+    }
+
+    // Memoize before recursing to handle cycles
+    memo.set(infoState, node)
+
+    if (isTerminal || actions.length === 0) return node
+
+    const { player, perfectRecall } = config
+    const opponent = 1 - player
+    const collisionPossible = infoOps.isCollisionPossible(infoState)
+
+    for (const [action, probability] of actions) {
+      if (probability <= 0) continue
+
+      // Placement successor (stone belongs to the policy's player)
+      const placementState = infoOps.infoStateAfterAction(infoState, action, player, perfectRecall)
+      const placementChild = build(placementState, depth + 1)
+      node.children.push({
+        action,
+        probability,
+        label: cellLabel(action, config.cols),
+        isCollision: false,
+        child: placementChild,
+      })
+
+      // Collision successor (stone belongs to opponent — reveals opponent stone)
+      if (collisionPossible) {
+        const collisionState = infoOps.infoStateAfterAction(infoState, action, opponent, perfectRecall)
+        // Only add if the collision state differs from placement
+        if (collisionState !== placementState) {
+          const collisionChild = build(collisionState, depth + 1)
+          node.children.push({
+            action,
+            probability,
+            label: cellLabel(action, config.cols),
+            isCollision: true,
+            child: collisionChild,
+          })
+        }
+      }
+    }
+
+    return node
+  }
+
+  let initialState = infoOps.initialInfoState(config.player)
+  if (config.perfectRecall) initialState += '\n'
+
+  const root = build(initialState, 0)
+  computeSubtreeSize(root)
+  return root
+}
+
+/** Compute subtreeSize for each node (total descendants). */
+function computeSubtreeSize(node: TreeNode, visited = new Set<number>()): number {
+  if (visited.has(node.id)) {
+    node.subtreeSize = 0
+    return 0 // already counted in another branch
+  }
+  visited.add(node.id)
+
+  if (node.children.length === 0) {
+    node.subtreeSize = 0
+    return 1
+  }
+  let total = 0
+  for (const edge of node.children) {
+    total += computeSubtreeSize(edge.child, visited)
+  }
+  node.subtreeSize = total
+  return total + 1
+}

--- a/game/src/investigation/TreeLayout.ts
+++ b/game/src/investigation/TreeLayout.ts
@@ -1,0 +1,135 @@
+import type { TreeNode } from './types'
+
+export interface LayoutConfig {
+  nodeWidth: number
+  nodeHeight: number
+  levelGap: number
+  siblingGap: number
+}
+
+export const DEFAULT_LAYOUT: LayoutConfig = {
+  nodeWidth: 80,
+  nodeHeight: 80,
+  levelGap: 60,
+  siblingGap: 20,
+}
+
+/**
+ * Assign (x, y) positions to all visible (non-collapsed) nodes.
+ *
+ * Uses a simplified layered tree layout:
+ * - Post-order: compute subtree widths bottom-up
+ * - Pre-order: assign x positions left-to-right, centering parents over children
+ * - Y = depth * (nodeHeight + levelGap)
+ *
+ * Collapsed nodes are treated as leaves (their children are not laid out).
+ * Returns the total bounding box size.
+ */
+export function layoutTree(root: TreeNode, config: LayoutConfig): { width: number; height: number } {
+  const { nodeWidth, nodeHeight, levelGap, siblingGap } = config
+
+  // Phase 1: compute subtree widths (post-order)
+  const widthOf = new Map<number, number>() // node.id → total subtree width
+
+  function computeWidth(node: TreeNode): number {
+    const visibleChildren = getVisibleChildren(node)
+    if (visibleChildren.length === 0) {
+      widthOf.set(node.id, nodeWidth)
+      return nodeWidth
+    }
+
+    let total = 0
+    for (let i = 0; i < visibleChildren.length; i++) {
+      if (i > 0) total += siblingGap
+      total += computeWidth(visibleChildren[i])
+    }
+    // Ensure parent is at least nodeWidth wide
+    const w = Math.max(total, nodeWidth)
+    widthOf.set(node.id, w)
+    return w
+  }
+
+  computeWidth(root)
+
+  // Phase 2: assign positions (pre-order)
+  let maxX = 0
+  let maxDepth = 0
+
+  function assignPositions(node: TreeNode, leftX: number): void {
+    const w = widthOf.get(node.id)!
+    node.x = leftX + w / 2
+    node.y = node.depth * (nodeHeight + levelGap)
+    maxX = Math.max(maxX, node.x + nodeWidth / 2)
+    maxDepth = Math.max(maxDepth, node.depth)
+
+    const visibleChildren = getVisibleChildren(node)
+    if (visibleChildren.length === 0) return
+
+    // Distribute children left-to-right within our subtree width
+    let childX = leftX
+    // If total children width < parent width, center the children block
+    let totalChildWidth = 0
+    for (let i = 0; i < visibleChildren.length; i++) {
+      if (i > 0) totalChildWidth += siblingGap
+      totalChildWidth += widthOf.get(visibleChildren[i].id)!
+    }
+    if (totalChildWidth < w) {
+      childX += (w - totalChildWidth) / 2
+    }
+
+    for (let i = 0; i < visibleChildren.length; i++) {
+      const cw = widthOf.get(visibleChildren[i].id)!
+      assignPositions(visibleChildren[i], childX)
+      childX += cw + siblingGap
+    }
+  }
+
+  assignPositions(root, 0)
+
+  return {
+    width: maxX + nodeWidth / 2,
+    height: (maxDepth + 1) * nodeHeight + maxDepth * levelGap,
+  }
+}
+
+/** Get visible children of a node (skip collapsed subtrees). */
+function getVisibleChildren(node: TreeNode): TreeNode[] {
+  if (node.collapsed || node.children.length === 0) return []
+  return node.children.map((edge) => edge.child)
+}
+
+/**
+ * Collect all visible nodes (for rendering).
+ * A node is visible if it is the root or its parent is not collapsed.
+ */
+export function collectVisibleNodes(root: TreeNode): TreeNode[] {
+  const result: TreeNode[] = []
+  function walk(node: TreeNode): void {
+    result.push(node)
+    if (!node.collapsed) {
+      for (const edge of node.children) {
+        walk(edge.child)
+      }
+    }
+  }
+  walk(root)
+  return result
+}
+
+/**
+ * Collect all visible edges (for rendering).
+ * An edge is visible if its parent node is not collapsed.
+ */
+export function collectVisibleEdges(root: TreeNode): Array<{ parent: TreeNode; edge: import('./types').TreeEdge }> {
+  const result: Array<{ parent: TreeNode; edge: import('./types').TreeEdge }> = []
+  function walk(node: TreeNode): void {
+    if (!node.collapsed) {
+      for (const edge of node.children) {
+        result.push({ parent: node, edge })
+        walk(edge.child)
+      }
+    }
+  }
+  walk(root)
+  return result
+}

--- a/game/src/investigation/TreeRenderer.ts
+++ b/game/src/investigation/TreeRenderer.ts
@@ -1,0 +1,415 @@
+import type { TreeNode, TreeEdge } from './types'
+import { layoutTree, collectVisibleNodes, collectVisibleEdges, DEFAULT_LAYOUT } from './TreeLayout'
+import type { LayoutConfig } from './TreeLayout'
+import { drawMiniBoard } from './MiniBoard'
+
+// Style tokens matching the warm board-game palette
+const CREAM = '#faf5ef'
+const MAUVE_DARK = '#995a5a'
+const MAUVE_LIGHT = '#e8d5d5'
+const TEXT = '#4a3535'
+const TEXT_MUTED = '#8a7070'
+const GREEN = '#5a9a5e'
+// green border available for future use: '#b5d8b7'
+const COLLISION_COLOR = '#c75000'
+const FONT = "'Nunito', -apple-system, BlinkMacSystemFont, sans-serif"
+
+const NODE_RADIUS = 8            // rounded rect corner radius
+const NODE_PADDING = 8           // padding around mini board
+const EDGE_LABEL_FONT_SIZE = 11
+const MIN_ZOOM = 0.1
+const MAX_ZOOM = 3.0
+const ZOOM_FACTOR = 1.08
+const DOUBLE_CLICK_MS = 350
+
+export interface TreeRendererCallbacks {
+  onNodeClick: (node: TreeNode) => void
+  onNodeDoubleClick: (node: TreeNode) => void
+}
+
+export class TreeRenderer {
+  private canvas: HTMLCanvasElement
+  private ctx: CanvasRenderingContext2D
+  private root: TreeNode
+  private rows: number
+  private cols: number
+  private layout: LayoutConfig
+  private callbacks: TreeRendererCallbacks
+
+  // Camera
+  private camX = 0
+  private camY = 0
+  private camScale = 1
+
+  // Interaction state
+  private dragging = false
+  private dragStartX = 0
+  private dragStartY = 0
+  private camStartX = 0
+  private camStartY = 0
+  private selectedNode: TreeNode | null = null
+  private lastClickTime = 0
+  private lastClickNode: TreeNode | null = null
+
+  // Cached visible elements
+  private visibleNodes: TreeNode[] = []
+  private visibleEdges: Array<{ parent: TreeNode; edge: TreeEdge }> = []
+  private treeWidth = 0
+  private treeHeight = 0
+
+  // RAF
+  private _rafId = 0
+  private _dirty = true
+
+  // Hex cell size for tree node thumbnails
+  private cellSize: number
+  // Logical (CSS) dimensions — stable reference for layout/hit-testing
+  private cssWidth = 0
+  private cssHeight = 0
+
+  constructor(
+    canvas: HTMLCanvasElement,
+    root: TreeNode,
+    rows: number,
+    cols: number,
+    layoutConfig: LayoutConfig = DEFAULT_LAYOUT,
+    callbacks: TreeRendererCallbacks,
+  ) {
+    this.canvas = canvas
+    this.ctx = canvas.getContext('2d')!
+    this.root = root
+    this.rows = rows
+    this.cols = cols
+    this.layout = layoutConfig
+    this.callbacks = callbacks
+
+    // Scale hex cells to fit inside node box
+    const maxDim = Math.max(rows, cols)
+    this.cellSize = Math.max(4, Math.min(8, Math.floor((layoutConfig.nodeWidth - NODE_PADDING * 2) / (maxDim * 1.8))))
+
+    this._resizeCanvas()
+    this.relayout()
+
+    // Event listeners
+    this.canvas.addEventListener('wheel', this._onWheel, { passive: false })
+    this.canvas.addEventListener('pointerdown', this._onPointerDown)
+    this.canvas.addEventListener('pointermove', this._onPointerMove)
+    this.canvas.addEventListener('pointerup', this._onPointerUp)
+    this.canvas.addEventListener('pointerleave', this._onPointerUp)
+    window.addEventListener('resize', this._onResize)
+
+    this._rafId = requestAnimationFrame(this._animate)
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  relayout(): void {
+    const bounds = layoutTree(this.root, this.layout)
+    this.treeWidth = bounds.width
+    this.treeHeight = bounds.height
+    this.visibleNodes = collectVisibleNodes(this.root)
+    this.visibleEdges = collectVisibleEdges(this.root)
+    this._dirty = true
+  }
+
+  selectNode(node: TreeNode | null): void {
+    this.selectedNode = node
+    this._dirty = true
+  }
+
+  fitToView(): void {
+    if (this.treeWidth === 0 || this.treeHeight === 0) return
+    const cw = this.cssWidth
+    const ch = this.cssHeight
+    const pad = 40
+    const scaleX = (cw - pad * 2) / this.treeWidth
+    const scaleY = (ch - pad * 2) / this.treeHeight
+    this.camScale = Math.min(scaleX, scaleY, MAX_ZOOM)
+    this.camScale = Math.max(this.camScale, MIN_ZOOM)
+    this.camX = (cw - this.treeWidth * this.camScale) / 2
+    this.camY = (ch - this.treeHeight * this.camScale) / 2 + pad / 2
+    this._dirty = true
+  }
+
+  dispose(): void {
+    cancelAnimationFrame(this._rafId)
+    this.canvas.removeEventListener('wheel', this._onWheel)
+    this.canvas.removeEventListener('pointerdown', this._onPointerDown)
+    this.canvas.removeEventListener('pointermove', this._onPointerMove)
+    this.canvas.removeEventListener('pointerup', this._onPointerUp)
+    this.canvas.removeEventListener('pointerleave', this._onPointerUp)
+    window.removeEventListener('resize', this._onResize)
+  }
+
+  // ── Render loop ────────────────────────────────────────────────────────────
+
+  private _animate = (): void => {
+    this._rafId = requestAnimationFrame(this._animate)
+    if (!this._dirty) return
+    this._dirty = false
+    this._draw()
+  }
+
+  private _draw(): void {
+    const ctx = this.ctx
+    const dpr = window.devicePixelRatio || 1
+
+    // Clear (in physical pixels, before DPR transform)
+    ctx.setTransform(1, 0, 0, 1, 0, 0)
+    ctx.fillStyle = CREAM
+    ctx.fillRect(0, 0, this.canvas.width, this.canvas.height)
+
+    // Apply DPR then camera transform (all subsequent draws in CSS pixel space)
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    ctx.translate(this.camX, this.camY)
+    ctx.scale(this.camScale, this.camScale)
+
+    // Draw edges first (behind nodes)
+    for (const { parent, edge } of this.visibleEdges) {
+      this._drawEdge(ctx, parent, edge)
+    }
+
+    // Draw nodes
+    for (const node of this.visibleNodes) {
+      this._drawNode(ctx, node)
+    }
+
+    ctx.restore()
+  }
+
+  private _drawNode(ctx: CanvasRenderingContext2D, node: TreeNode): void {
+    const { nodeWidth, nodeHeight } = this.layout
+    const x = node.x - nodeWidth / 2
+    const y = node.y
+
+    // Background
+    const isSelected = node === this.selectedNode
+    ctx.beginPath()
+    this._roundRect(ctx, x, y, nodeWidth, nodeHeight, NODE_RADIUS)
+    ctx.fillStyle = '#fff'
+    ctx.fill()
+    ctx.strokeStyle = isSelected ? GREEN : MAUVE_LIGHT
+    ctx.lineWidth = isSelected ? 2.5 : 1.5
+    ctx.stroke()
+
+    // Mini board
+    drawMiniBoard(
+      ctx,
+      node.x,
+      y + nodeHeight / 2,
+      node.boardView,
+      this.rows,
+      this.cols,
+      this.cellSize,
+      node.actions.length > 0
+        ? { highlightActions: node.actions.map(([a]) => a) }
+        : undefined,
+    )
+
+    // Terminal badge
+    if (node.isTerminal) {
+      const badgeW = 28
+      const badgeH = 12
+      const bx = x + nodeWidth - badgeW - 3
+      const by = y + 3
+      ctx.beginPath()
+      this._roundRect(ctx, bx, by, badgeW, badgeH, 3)
+      ctx.fillStyle = MAUVE_DARK
+      ctx.fill()
+      ctx.fillStyle = '#fff'
+      ctx.font = `bold 8px ${FONT}`
+      ctx.textAlign = 'center'
+      ctx.textBaseline = 'middle'
+      ctx.fillText('END', bx + badgeW / 2, by + badgeH / 2)
+    }
+
+    // Collapse badge: show "+N" if collapsed and has children
+    if (node.collapsed && node.children.length > 0) {
+      const label = `+${node.subtreeSize}`
+      ctx.font = `bold 10px ${FONT}`
+      const tw = ctx.measureText(label).width
+      const badgeW = tw + 8
+      const badgeH = 16
+      const bx = node.x - badgeW / 2
+      const by = y + nodeHeight + 4
+      ctx.beginPath()
+      this._roundRect(ctx, bx, by, badgeW, badgeH, 4)
+      ctx.fillStyle = MAUVE_LIGHT
+      ctx.fill()
+      ctx.strokeStyle = MAUVE_DARK
+      ctx.lineWidth = 1
+      ctx.stroke()
+      ctx.fillStyle = TEXT
+      ctx.textAlign = 'center'
+      ctx.textBaseline = 'middle'
+      ctx.fillText(label, node.x, by + badgeH / 2)
+    }
+  }
+
+  private _drawEdge(ctx: CanvasRenderingContext2D, parent: TreeNode, edge: TreeEdge): void {
+    const { nodeHeight } = this.layout
+    const child = edge.child
+
+    const x0 = parent.x
+    const y0 = parent.y + nodeHeight
+    const x1 = child.x
+    const y1 = child.y
+
+    // Bezier curve
+    const cpY = (y0 + y1) / 2
+    ctx.beginPath()
+    ctx.moveTo(x0, y0)
+    ctx.bezierCurveTo(x0, cpY, x1, cpY, x1, y1)
+
+    if (edge.isCollision) {
+      ctx.strokeStyle = COLLISION_COLOR
+      ctx.setLineDash([4, 3])
+    } else {
+      ctx.strokeStyle = TEXT_MUTED
+      ctx.setLineDash([])
+    }
+    ctx.lineWidth = 1.5
+    ctx.stroke()
+    ctx.setLineDash([])
+
+    // Edge label at midpoint
+    const mx = (x0 + x1) / 2
+    const my = (y0 + y1) / 2
+    const label = edge.isCollision
+      ? `${edge.label}(c)`
+      : `${edge.label}: ${edge.probability.toFixed(2)}`
+
+    ctx.font = `${EDGE_LABEL_FONT_SIZE}px ${FONT}`
+    const tw = ctx.measureText(label).width
+    // Background pill
+    ctx.fillStyle = '#fff'
+    ctx.globalAlpha = 0.85
+    ctx.beginPath()
+    this._roundRect(ctx, mx - tw / 2 - 4, my - 8, tw + 8, 16, 4)
+    ctx.fill()
+    ctx.globalAlpha = 1.0
+    // Text
+    ctx.fillStyle = edge.isCollision ? COLLISION_COLOR : TEXT
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillText(label, mx, my)
+  }
+
+  private _roundRect(
+    ctx: CanvasRenderingContext2D,
+    x: number, y: number, w: number, h: number, r: number,
+  ): void {
+    ctx.moveTo(x + r, y)
+    ctx.arcTo(x + w, y, x + w, y + h, r)
+    ctx.arcTo(x + w, y + h, x, y + h, r)
+    ctx.arcTo(x, y + h, x, y, r)
+    ctx.arcTo(x, y, x + w, y, r)
+  }
+
+  // ── Hit testing ────────────────────────────────────────────────────────────
+
+  private _hitTestNode(screenX: number, screenY: number): TreeNode | null {
+    // Convert screen coords to tree coords
+    const tx = (screenX - this.camX) / this.camScale
+    const ty = (screenY - this.camY) / this.camScale
+    const { nodeWidth, nodeHeight } = this.layout
+
+    for (let i = this.visibleNodes.length - 1; i >= 0; i--) {
+      const node = this.visibleNodes[i]
+      const nx = node.x - nodeWidth / 2
+      const ny = node.y
+      if (tx >= nx && tx <= nx + nodeWidth && ty >= ny && ty <= ny + nodeHeight) {
+        return node
+      }
+    }
+    return null
+  }
+
+  // ── Event handlers ─────────────────────────────────────────────────────────
+
+  private _resizeCanvas(): void {
+    const rect = this.canvas.parentElement!.getBoundingClientRect()
+    const dpr = window.devicePixelRatio || 1
+    this.cssWidth = rect.width
+    this.cssHeight = rect.height
+    this.canvas.width = rect.width * dpr
+    this.canvas.height = rect.height * dpr
+    this.canvas.style.width = `${rect.width}px`
+    this.canvas.style.height = `${rect.height}px`
+    this._dirty = true
+  }
+
+  private _onResize = (): void => {
+    this._resizeCanvas()
+  }
+
+  private _onWheel = (e: WheelEvent): void => {
+    e.preventDefault()
+    const rect = this.canvas.getBoundingClientRect()
+    const mx = e.clientX - rect.left
+    const my = e.clientY - rect.top
+
+    const oldScale = this.camScale
+    const factor = e.deltaY < 0 ? ZOOM_FACTOR : 1 / ZOOM_FACTOR
+    this.camScale = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, this.camScale * factor))
+
+    // Zoom towards cursor
+    this.camX = mx - (mx - this.camX) * (this.camScale / oldScale)
+    this.camY = my - (my - this.camY) * (this.camScale / oldScale)
+    this._dirty = true
+  }
+
+  private _onPointerDown = (e: PointerEvent): void => {
+    const rect = this.canvas.getBoundingClientRect()
+    const mx = e.clientX - rect.left
+    const my = e.clientY - rect.top
+
+    // Check for node click (CSS pixel coords — camera is in CSS space)
+    const node = this._hitTestNode(mx, my)
+
+    if (node) {
+      const now = Date.now()
+      if (now - this.lastClickTime < DOUBLE_CLICK_MS && this.lastClickNode === node) {
+        // Double-click: expand/collapse
+        this.callbacks.onNodeDoubleClick(node)
+        this.lastClickTime = 0
+        this.lastClickNode = null
+        return
+      }
+      this.lastClickTime = now
+      this.lastClickNode = node
+      this.callbacks.onNodeClick(node)
+      return
+    }
+
+    // Start drag
+    this.dragging = true
+    this.dragStartX = e.clientX
+    this.dragStartY = e.clientY
+    this.camStartX = this.camX
+    this.camStartY = this.camY
+    this.canvas.style.cursor = 'grabbing'
+  }
+
+  private _onPointerMove = (e: PointerEvent): void => {
+    if (!this.dragging) {
+      // Hover cursor
+      const rect = this.canvas.getBoundingClientRect()
+      const node = this._hitTestNode(e.clientX - rect.left, e.clientY - rect.top)
+      this.canvas.style.cursor = node ? 'pointer' : 'grab'
+      return
+    }
+    const dx = e.clientX - this.dragStartX
+    const dy = e.clientY - this.dragStartY
+    this.camX = this.camStartX + dx
+    this.camY = this.camStartY + dy
+    this._dirty = true
+  }
+
+  private _onPointerUp = (): void => {
+    if (this.dragging) {
+      this.dragging = false
+      this.canvas.style.cursor = 'grab'
+    }
+  }
+}

--- a/game/src/investigation/policyImport.ts
+++ b/game/src/investigation/policyImport.ts
@@ -1,0 +1,90 @@
+import type { ActionProb, Policy, StrategyConfig, ExportedPolicy } from '../strategy/types'
+
+/** Convert exported dict-of-dicts JSON to internal Policy Map. */
+export function parseExportedPolicy(data: unknown): { config: StrategyConfig; policy: Policy } {
+  const obj = data as Record<string, unknown>
+  if (typeof obj !== 'object' || obj === null) throw new Error('Invalid policy: not an object')
+  if (typeof obj.player !== 'number') throw new Error('Invalid policy: missing player')
+  if (typeof obj.rows !== 'number') throw new Error('Invalid policy: missing rows')
+  if (typeof obj.cols !== 'number') throw new Error('Invalid policy: missing cols')
+  if (typeof obj.policy !== 'object' || obj.policy === null) throw new Error('Invalid policy: missing policy map')
+
+  const exported = obj as unknown as ExportedPolicy
+  const config: StrategyConfig = {
+    player: exported.player,
+    rows: exported.rows,
+    cols: exported.cols,
+    perfectRecall: exported.perfectRecall ?? false,
+  }
+
+  const totalCells = exported.rows * exported.cols
+  const policy: Policy = new Map()
+  for (const [infoState, actionDict] of Object.entries(exported.policy)) {
+    const actions: ActionProb[] = []
+    for (const [actionStr, prob] of Object.entries(actionDict)) {
+      const action = Number(actionStr)
+      const probability = Number(prob)
+      if (!Number.isFinite(action) || action < 0 || action >= totalCells || action !== Math.floor(action)) {
+        throw new Error(`Invalid action "${actionStr}" in info state`)
+      }
+      if (!Number.isFinite(probability) || probability < 0 || probability > 1) {
+        throw new Error(`Invalid probability ${prob} for action ${actionStr}`)
+      }
+      actions.push([action, probability])
+    }
+    if (actions.length > 0) {
+      policy.set(infoState, actions)
+    }
+  }
+
+  if (policy.size === 0) throw new Error('Invalid policy: no info states')
+  return { config, policy }
+}
+
+/** Open file picker, load + parse a policy JSON. Null if cancelled. */
+export function loadPolicyFromFile(): Promise<{ config: StrategyConfig; policy: Policy } | null> {
+  return new Promise((resolve) => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = '.json'
+    input.style.display = 'none'
+    document.body.appendChild(input)
+
+    let resolved = false
+
+    input.addEventListener('change', () => {
+      const file = input.files?.[0]
+      input.remove()
+      if (!file) { resolved = true; resolve(null); return }
+
+      const reader = new FileReader()
+      reader.onload = () => {
+        try {
+          const data = JSON.parse(reader.result as string)
+          resolved = true
+          resolve(parseExportedPolicy(data))
+        } catch (err) {
+          console.error('Failed to parse policy JSON:', err)
+          resolved = true
+          resolve(null)
+        }
+      }
+      reader.onerror = () => { resolved = true; resolve(null) }
+      reader.readAsText(file)
+    })
+
+    // Handle cancel: file picker closed without selecting
+    // Focus returns to window after picker closes
+    window.addEventListener('focus', () => {
+      setTimeout(() => {
+        if (!resolved) {
+          input.remove()
+          resolved = true
+          resolve(null)
+        }
+      }, 300)
+    }, { once: true })
+
+    input.click()
+  })
+}

--- a/game/src/investigation/types.ts
+++ b/game/src/investigation/types.ts
@@ -1,0 +1,25 @@
+import type { ActionProb } from '../strategy/types'
+
+export interface TreeNode {
+  id: number
+  infoState: string
+  boardView: Int8Array
+  actions: ActionProb[]
+  children: TreeEdge[]
+  depth: number
+  isTerminal: boolean
+  // Layout (set by TreeLayout)
+  x: number
+  y: number
+  // UI state
+  collapsed: boolean
+  subtreeSize: number
+}
+
+export interface TreeEdge {
+  action: number
+  probability: number
+  label: string
+  isCollision: boolean
+  child: TreeNode
+}

--- a/game/src/scenes/BoardScene.ts
+++ b/game/src/scenes/BoardScene.ts
@@ -11,6 +11,8 @@ import { ActionPanel } from '../ui/ActionPanel'
 import { InfoPanel } from '../ui/InfoPanel'
 import { CompletionPanel } from '../ui/CompletionPanel'
 import { MainMenuPanel } from '../ui/MainMenuPanel'
+import { InvestigationView } from '../investigation/InvestigationView'
+import { loadPolicyFromFile } from '../investigation/policyImport'
 import { ensureAudioReady, playThock, playPlace, playDrop, playReveal, playVanish, playChime } from '../audio/SoundEngine'
 
 const BOARD_ROWS = 4
@@ -41,6 +43,7 @@ export class BoardScene {
   private _menuOpen = false
   private _setupOpen = false
   private _completionOpen = false
+  private _investigationOpen = false
   private _sessionToken = 0 // incremented on each menu return; guards stale async continuations
   private stratGen: StrategyGenerator | null = null
   private mainMenu!: MainMenuPanel
@@ -250,7 +253,7 @@ export class BoardScene {
   private _confirmingLeave = false
 
   private _onKeyDown = (e: KeyboardEvent): void => {
-    if (this._menuOpen || this._setupOpen || this._completionOpen || this._confirmingLeave) return
+    if (this._menuOpen || this._setupOpen || this._completionOpen || this._confirmingLeave || this._investigationOpen) return
     if (e.key === 'Escape') {
       if (this.stratGen && this.stratGen.progress.assigned > 0) {
         this._confirmLeave()
@@ -355,6 +358,23 @@ export class BoardScene {
           this.infoPanel.show()
           this._updateStrategyView()
           return
+        }
+
+        case 'strategy-investigation': {
+          const loaded = await loadPolicyFromFile()
+          if (!loaded) {
+            // Cancelled file picker — loop back to menu
+            this._menuOpen = true
+            this.controls.autoRotate = true
+            this.controls.autoRotateSpeed = 0.3
+            continue
+          }
+          await this._runInvestigation(loaded.policy, loaded.config)
+          // Return to menu after investigation exits
+          this._menuOpen = true
+          this.controls.autoRotate = true
+          this.controls.autoRotateSpeed = 0.3
+          continue
         }
       }
     }
@@ -567,11 +587,38 @@ export class BoardScene {
       } else if (action === 'new') {
         this._returnToMenu()
         return
+      } else if (action === 'investigate') {
+        this._completionOpen = false
+        const policy = this.stratGen!.policy
+        const config = {
+          rows: this.stratGen!.rows,
+          cols: this.stratGen!.cols,
+          player: this.stratGen!.player,
+          perfectRecall: this.stratGen!.perfectRecall,
+        }
+        await this._runInvestigation(policy, config)
+        // Return to completion modal (strategy preserved) — user can download/new/dismiss
+        continue
       } else {
         // Dismissed — let user keep inspecting the completed board
         this._completionOpen = false
         return
       }
+    }
+  }
+
+  private async _runInvestigation(policy: import('../strategy/types').Policy, config: import('../strategy/types').StrategyConfig): Promise<void> {
+    const token = this._sessionToken
+    const infoOps = await InfoStateOps.create(config.rows, config.cols)
+    if (token !== this._sessionToken) return
+
+    this._investigationOpen = true
+    const view = new InvestigationView(this.container)
+    try {
+      await view.run(policy, config, infoOps)
+    } finally {
+      view.dispose()
+      this._investigationOpen = false
     }
   }
 

--- a/game/src/strategy/types.ts
+++ b/game/src/strategy/types.ts
@@ -21,3 +21,12 @@ export interface StrategyConfig {
   player: number         // 0 = Black, 1 = White
   perfectRecall: boolean
 }
+
+/** JSON format exported by StrategyGenerator.exportPolicy(). */
+export interface ExportedPolicy {
+  player: number
+  rows: number
+  cols: number
+  perfectRecall: boolean
+  policy: Record<string, Record<string, number>>
+}

--- a/game/src/ui/CompletionPanel.ts
+++ b/game/src/ui/CompletionPanel.ts
@@ -17,7 +17,7 @@ export interface CompletionStats {
   infoStates: number
 }
 
-export type CompletionAction = 'download' | 'new' | 'dismiss'
+export type CompletionAction = 'download' | 'new' | 'dismiss' | 'investigate'
 
 /**
  * Completion modal shown when a strategy is fully built.
@@ -97,6 +97,27 @@ export class CompletionPanel {
       this._resolve('download')
     })
     btnRow.appendChild(downloadBtn)
+
+    const investigateBtn = this._makeBtn('Investigate', GREEN, '#fff', `
+      flex: 1; font-weight: 800; border: none;
+      box-shadow: 0 3px 0 #3d7a3f, 0 4px 12px rgba(60, 100, 60, 0.2);
+    `)
+    investigateBtn.addEventListener('mousedown', () => {
+      investigateBtn.style.transform = 'translateY(2px)'
+      investigateBtn.style.boxShadow = '0 1px 0 #3d7a3f, 0 2px 6px rgba(60, 100, 60, 0.2)'
+    })
+    investigateBtn.addEventListener('mouseup', () => {
+      investigateBtn.style.transform = ''
+      investigateBtn.style.boxShadow = '0 3px 0 #3d7a3f, 0 4px 12px rgba(60, 100, 60, 0.2)'
+    })
+    investigateBtn.addEventListener('mouseover', () => { investigateBtn.style.background = '#4a8a4e' })
+    investigateBtn.addEventListener('mouseout', () => {
+      investigateBtn.style.background = GREEN
+      investigateBtn.style.transform = ''
+      investigateBtn.style.boxShadow = '0 3px 0 #3d7a3f, 0 4px 12px rgba(60, 100, 60, 0.2)'
+    })
+    investigateBtn.addEventListener('click', () => this._resolve('investigate'))
+    btnRow.appendChild(investigateBtn)
 
     const newBtn = this._makeBtn('New Strategy', CREAM, TEXT, `
       flex: 1; border: 2px solid ${MAUVE_LIGHT};

--- a/game/src/ui/MainMenuPanel.ts
+++ b/game/src/ui/MainMenuPanel.ts
@@ -10,7 +10,7 @@ const TEXT_MUTED = '#8a7070'
 const SHADOW = '0 8px 32px rgba(100, 60, 60, 0.18), 0 2px 8px rgba(100, 60, 60, 0.10)'
 const RADIUS = '14px'
 
-export type MenuChoice = 'strategy-generator'
+export type MenuChoice = 'strategy-generator' | 'strategy-investigation'
 
 interface MenuItem {
   id: MenuChoice | null
@@ -20,7 +20,7 @@ interface MenuItem {
 
 const MENU_ITEMS: MenuItem[] = [
   { id: 'strategy-generator', label: 'Strategy Generator', enabled: true },
-  { id: null, label: 'Strategy Investigation', enabled: false },
+  { id: 'strategy-investigation', label: 'Strategy Investigation', enabled: true },
   { id: null, label: 'Strategy Walker', enabled: false },
   { id: null, label: 'Game Tree Explorer', enabled: false },
   { id: null, label: 'Convergence Plots', enabled: false },


### PR DESCRIPTION
## Summary
- Full-screen Canvas 2D tree diagram for browsing completed policies
- Miniature pointy-top hex boards at each node (thesis orientation with border edge indicators)
- Bezier edges with action labels, probabilities, dashed orange collision branches
- Zoom/pan, collapsible subtrees (3 levels default), click-to-select with detail sidebar
- Two entry points: main menu file upload + completion panel "Investigate" button
- Memoized tree builder prevents exponential blowup on shared info states
- Validated policy import with per-entry action/probability checks
- Investigation from completion preserves strategy (returns to modal on exit)

## Test plan
- [ ] Load a 2x2 policy JSON via main menu → Strategy Investigation
- [ ] Verify tree renders with mini boards, edge labels, collision branches
- [ ] Click nodes → detail sidebar with enlarged board, info state, actions
- [ ] Double-click to expand/collapse subtrees
- [ ] Zoom (scroll) and pan (drag) the tree
- [ ] Build a strategy → completion → Investigate → Esc returns to completion modal
- [ ] Verify malformed JSON files are rejected gracefully
- [ ] `cd game && npx tsc --noEmit` passes
- [ ] `cd game && npx vite build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)