### PR TITLE
feat(game): SVG export, MCCFR policy loading, and investigation UX

### DIFF
--- a/crates/core/src/solver/mccfr.rs
+++ b/crates/core/src/solver/mccfr.rs
@@ -130,6 +130,14 @@ impl MCCFRSolver {
         self.epsilon
     }
 
+    pub fn rows(&self) -> usize {
+        self.rows
+    }
+
+    pub fn cols(&self) -> usize {
+        self.cols
+    }
+
     /// Set an optional pONE database for pruning determined subtrees.
     pub fn set_pone_db(&mut self, db: PoneDb) {
         self.pone_db = Some(db);

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -301,6 +301,14 @@ impl MCCFRSolver {
         self.inner.epsilon()
     }
 
+    fn rows(&self) -> usize {
+        self.inner.rows()
+    }
+
+    fn cols(&self) -> usize {
+        self.inner.cols()
+    }
+
     fn get_average_strategy(&self) -> HashMap<String, Vec<(usize, f32)>> {
         self.inner.get_average_strategy()
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -282,11 +282,15 @@ Ported from the old Python/Tkinter `darkhex/gui/` PolGen tool. Lets researchers 
 | Terminal detection via HexBoard | Reuse union-find | Consistent win detection with the game engine; no duplicate logic |
 | Board-centric UX | Click tiles, overlays on 3D board | Researchers see the board as the player sees it, not an abstract tree |
 
-**Planned features**:
+**Completed features**:
 - Strategy investigation screen (browse completed strategy: step through info states, view assigned probabilities on the board, navigate the decision tree)
-- Strategy diagram export (generate visual game tree / strategy diagrams as SVG/PDF, similar to thesis figures — show info states, branching, and probability assignments)
-- Strategy walker (step through MCCFR policies)
-- Game tree exploration
+- SVG export of strategy tree diagrams (publication-quality vector output matching the canvas rendering)
+- MCCFR policy loading (Python CLI converts solver checkpoints to JSON for browser import; `scripts/export_policy.py`)
+- Depth slider + Expand All / Collapse All controls for navigating large trees
+- Keyboard navigation (arrow keys for parent/child/sibling traversal, Enter/Space to toggle collapse)
+
+**Planned features**:
+- Strategy walker (step through MCCFR policies interactively in the 3D board view)
 - Live MCCFR convergence plots
 
 ## Data Flow

--- a/game/src/investigation/InvestigationView.ts
+++ b/game/src/investigation/InvestigationView.ts
@@ -2,9 +2,10 @@ import type { Policy, StrategyConfig } from '../strategy/types'
 import type { InfoStateOps } from '../engine/InfoStateOps'
 import type { TreeNode } from './types'
 import { buildTree, cellLabel } from './TreeBuilder'
-import { DEFAULT_LAYOUT } from './TreeLayout'
+import { DEFAULT_LAYOUT, computeMaxDepth, setCollapseDepth } from './TreeLayout'
 import { TreeRenderer } from './TreeRenderer'
 import { drawMiniBoard, miniBoardSize } from './MiniBoard'
+import { exportTreeSvg, downloadSvg } from './SvgExport'
 
 const FONT = "'Nunito', -apple-system, BlinkMacSystemFont, sans-serif"
 const CREAM = '#faf5ef'
@@ -17,7 +18,7 @@ const SIDEBAR_WIDTH = 280
 
 /**
  * Full-screen investigation overlay.
- * Composes TreeRenderer (canvas) + detail sidebar + bottom bar.
+ * Composes TreeRenderer (canvas) + detail sidebar + top bar.
  */
 export class InvestigationView {
   private parent: HTMLElement
@@ -29,6 +30,7 @@ export class InvestigationView {
   private root: TreeNode | null = null
   private rows = 0
   private cols = 0
+  private config: StrategyConfig | null = null
 
   constructor(parent: HTMLElement) {
     this.parent = parent
@@ -37,9 +39,14 @@ export class InvestigationView {
   async run(policy: Policy, config: StrategyConfig, infoOps: InfoStateOps): Promise<void> {
     this.rows = config.rows
     this.cols = config.cols
+    this.config = config
 
     // Build tree
     this.root = buildTree(policy, infoOps, config)
+    const maxDepth = computeMaxDepth(this.root)
+
+    // Default: collapse at depth 1 (root expanded, children collapsed)
+    setCollapseDepth(this.root, 1)
 
     // Create overlay
     this.overlay = document.createElement('div')
@@ -52,9 +59,9 @@ export class InvestigationView {
     // ── Top bar ─────────────────────────────────────────────────────
     const topBar = document.createElement('div')
     topBar.style.cssText = `
-      display: flex; align-items: center; gap: 12px; padding: 10px 16px;
+      display: flex; align-items: center; gap: 10px; padding: 10px 16px;
       border-bottom: 1px solid ${MAUVE_LIGHT}; flex-shrink: 0;
-      background: ${CREAM};
+      background: ${CREAM}; flex-wrap: wrap;
     `
 
     const escBadge = document.createElement('span')
@@ -66,12 +73,88 @@ export class InvestigationView {
     topBar.appendChild(escBadge)
 
     const fitBtn = this._makeBtn('Fit to View', MAUVE_LIGHT, TEXT)
-    fitBtn.addEventListener('click', () => this.renderer?.fitToView())
+    fitBtn.addEventListener('click', () => {
+      this.renderer?.fitToView()
+    })
     topBar.appendChild(fitBtn)
 
+    const exportBtn = this._makeBtn('Export SVG', MAUVE_DARK, '#fff')
+    exportBtn.addEventListener('click', () => {
+      if (!this.root) return
+      const svg = exportTreeSvg(this.root, this.rows, this.cols, DEFAULT_LAYOUT)
+      downloadSvg(svg, `strategy_${this.rows}x${this.cols}.svg`)
+    })
+    topBar.appendChild(exportBtn)
+
+    // ── Separator ──
+    topBar.appendChild(this._makeSep())
+
+    // ── Depth control ──
+    const depthWrap = document.createElement('div')
+    depthWrap.style.cssText = `display: flex; align-items: center; gap: 6px;`
+
+    const depthLabel = document.createElement('span')
+    depthLabel.style.cssText = `font-size: 12px; font-weight: 700; color: ${TEXT_MUTED};`
+    depthLabel.textContent = 'Depth:'
+
+    const depthValue = document.createElement('span')
+    depthValue.style.cssText = `font-size: 12px; font-weight: 800; color: ${TEXT}; min-width: 16px; text-align: center;`
+    depthValue.textContent = '1'
+
+    const depthSlider = document.createElement('input')
+    depthSlider.type = 'range'
+    depthSlider.min = '0'
+    depthSlider.max = String(maxDepth)
+    depthSlider.value = '1'
+    depthSlider.style.cssText = `width: 100px; accent-color: ${MAUVE_DARK}; cursor: pointer;`
+    depthSlider.addEventListener('input', () => {
+      const depth = Number(depthSlider.value)
+      depthValue.textContent = String(depth)
+      if (this.root) {
+        setCollapseDepth(this.root, depth)
+        this.renderer?.relayout()
+        this.renderer?.fitToView()
+      }
+    })
+
+    depthWrap.appendChild(depthLabel)
+    depthWrap.appendChild(depthSlider)
+    depthWrap.appendChild(depthValue)
+    topBar.appendChild(depthWrap)
+
+    const expandAllBtn = this._makeBtn('Expand All', MAUVE_LIGHT, TEXT)
+    expandAllBtn.addEventListener('click', () => {
+      if (this.root) {
+        depthSlider.value = String(maxDepth)
+        depthValue.textContent = String(maxDepth)
+        setCollapseDepth(this.root, maxDepth + 1)
+        this.renderer?.relayout()
+        this.renderer?.fitToView()
+      }
+    })
+    topBar.appendChild(expandAllBtn)
+
+    const collapseAllBtn = this._makeBtn('Collapse All', MAUVE_LIGHT, TEXT)
+    collapseAllBtn.addEventListener('click', () => {
+      if (this.root) {
+        depthSlider.value = '0'
+        depthValue.textContent = '0'
+        setCollapseDepth(this.root, 0)
+        this.renderer?.relayout()
+        this.renderer?.fitToView()
+      }
+    })
+    topBar.appendChild(collapseAllBtn)
+
+    // ── Spacer + summary ──
     const spacer = document.createElement('div')
     spacer.style.flex = '1'
     topBar.appendChild(spacer)
+
+    const navHint = document.createElement('span')
+    navHint.style.cssText = `font-size: 11px; color: ${TEXT_MUTED}; margin-right: 8px;`
+    navHint.textContent = '\u2190\u2191\u2192\u2193 navigate \u00B7 Enter toggle'
+    topBar.appendChild(navHint)
 
     const playerName = config.player === 0 ? 'Black' : 'White'
     const playerColor = config.player === 0 ? '#506080' : MAUVE_DARK
@@ -115,7 +198,7 @@ export class InvestigationView {
     this.renderer = new TreeRenderer(
       canvas, this.root, config.rows, config.cols, DEFAULT_LAYOUT,
       {
-        onNodeClick: (node) => this._showDetail(node, config),
+        onNodeClick: (node) => this._selectAndShow(node),
         onNodeDoubleClick: (node) => this._toggleCollapse(node),
       },
     )
@@ -126,6 +209,27 @@ export class InvestigationView {
       this._onKeyDown = (e: KeyboardEvent) => {
         if (e.key === 'Escape') {
           resolve()
+          return
+        }
+
+        // Arrow key navigation
+        if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+          e.preventDefault()
+          const current = this.renderer?.getSelectedNode() ?? null
+          const next = this.renderer?.navigateKey(e.key, current)
+          if (next) {
+            this._selectAndShow(next)
+            this.renderer?.panToNode(next)
+          }
+          return
+        }
+
+        // Enter/Space: toggle collapse on selected node
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          const sel = this.renderer?.getSelectedNode()
+          if (sel) this._toggleCollapse(sel)
+          return
         }
       }
       window.addEventListener('keydown', this._onKeyDown)
@@ -140,11 +244,20 @@ export class InvestigationView {
     this.renderer = null
   }
 
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+
+  private _selectAndShow(node: TreeNode): void {
+    if (!this.config) return
+    this.renderer?.selectNode(node)
+    this._showDetail(node, this.config)
+    // Sidebar visibility change alters canvas flex width — trigger resize
+    requestAnimationFrame(() => this.renderer?.resize())
+  }
+
   // ── Detail sidebar ──────────────────────────────────────────────────────────
 
   private _showDetail(node: TreeNode, config: StrategyConfig): void {
     if (!this.detailEl) return
-    this.renderer?.selectNode(node)
     this.detailEl.style.display = 'flex'
     this.detailEl.innerHTML = ''
 
@@ -268,5 +381,11 @@ export class InvestigationView {
     btn.addEventListener('mouseover', () => { btn.style.filter = 'brightness(0.94)' })
     btn.addEventListener('mouseout', () => { btn.style.filter = '' })
     return btn
+  }
+
+  private _makeSep(): HTMLSpanElement {
+    const sep = document.createElement('span')
+    sep.style.cssText = `width: 1px; height: 20px; background: ${MAUVE_LIGHT}; flex-shrink: 0;`
+    return sep
   }
 }

--- a/game/src/investigation/InvestigationView.ts
+++ b/game/src/investigation/InvestigationView.ts
@@ -343,6 +343,7 @@ export class InvestigationView {
       `Children: ${node.children.length}`,
       `Subtree: ${node.subtreeSize} nodes`,
       node.isTerminal ? `Terminal` : null,
+      node.isMissing ? `Missing policy` : null,
     ].filter(Boolean)
     meta.textContent = items.join(' \u00B7 ')
     this.detailEl.appendChild(meta)

--- a/game/src/investigation/SvgExport.ts
+++ b/game/src/investigation/SvgExport.ts
@@ -279,6 +279,18 @@ export function exportTreeSvg(
       )
     }
 
+    // Missing policy badge
+    if (node.isMissing) {
+      const badgeW = 12
+      const badgeH = 12
+      const bx = x + nodeWidth - badgeW - 3
+      const by = y + 3
+      parts.push(
+        `<rect x="${fmt(bx)}" y="${fmt(by)}" width="${badgeW}" height="${badgeH}" rx="3" fill="#d4920a"/>`,
+        `<text x="${fmt(bx + badgeW / 2)}" y="${fmt(by + badgeH / 2)}" text-anchor="middle" dominant-baseline="central" style="font-size:9px;font-weight:bold;fill:#fff">?</text>`,
+      )
+    }
+
     // Collapse badge
     if (node.collapsed && node.children.length > 0) {
       const label = `+${node.subtreeSize}`

--- a/game/src/investigation/SvgExport.ts
+++ b/game/src/investigation/SvgExport.ts
@@ -1,0 +1,323 @@
+/**
+ * Export the strategy tree as a publication-quality SVG.
+ *
+ * Walks the same TreeNode / TreeEdge structures used by TreeRenderer
+ * and emits SVG elements with matching geometry and style tokens.
+ */
+
+import type { TreeNode } from './types'
+import type { LayoutConfig } from './TreeLayout'
+import { collectVisibleNodes, collectVisibleEdges } from './TreeLayout'
+
+// ── Style tokens (same as TreeRenderer / InvestigationView) ─────────────────
+
+const CREAM = '#faf5ef'
+const MAUVE_DARK = '#995a5a'
+const MAUVE_LIGHT = '#e8d5d5'
+const TEXT = '#4a3535'
+const TEXT_MUTED = '#8a7070'
+const COLLISION_COLOR = '#c75000'
+const FONT = "'Nunito', -apple-system, BlinkMacSystemFont, sans-serif"
+
+const NODE_RADIUS = 8
+const EDGE_LABEL_FONT_SIZE = 11
+
+// MiniBoard colors
+const MB_EMPTY = '#e0b8b8'
+const MB_BLACK = '#506080'
+const MB_WHITE = '#e8e0d8'
+const MB_HIGHLIGHT = '#81c784'
+const MB_OUTLINE = '#2a2a30'
+const MB_EDGE_BLACK = '#506080'
+const MB_EDGE_WHITE = '#c8beb4'
+
+const SQRT3 = Math.sqrt(3)
+
+// ── Hex math (duplicated from MiniBoard.ts — pure arithmetic) ───────────────
+
+function hexCenter(row: number, col: number, r: number): [number, number] {
+  const x = SQRT3 * r * col + (SQRT3 / 2) * r * row
+  const y = 1.5 * r * row
+  return [x, y]
+}
+
+function vtx(cx: number, cy: number, r: number, i: number): [number, number] {
+  const angle = -Math.PI / 2 + (Math.PI / 3) * i
+  return [cx + r * Math.cos(angle), cy + r * Math.sin(angle)]
+}
+
+function fmt(n: number): string {
+  return n.toFixed(2)
+}
+
+// ── SVG mini board ──────────────────────────────────────────────────────────
+
+function svgMiniBoard(
+  cx: number,
+  cy: number,
+  boardView: Int8Array,
+  rows: number,
+  cols: number,
+  cellSize: number,
+  highlightActions?: number[],
+): string {
+  const highlightSet = highlightActions ? new Set(highlightActions) : null
+  const r = cellSize * 0.92
+
+  // Center the board at (cx, cy)
+  const [firstX, firstY] = hexCenter(0, 0, cellSize)
+  const [lastX, lastY] = hexCenter(rows - 1, cols - 1, cellSize)
+  const ox = cx - (firstX + lastX) / 2
+  const oy = cy - (firstY + lastY) / 2
+
+  const parts: string[] = []
+
+  // Hex cells
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const idx = row * cols + col
+      const [hx, hy] = hexCenter(row, col, cellSize)
+      const px = hx + ox
+      const py = hy + oy
+
+      const cell = boardView[idx]
+      let fill: string
+      if (highlightSet?.has(idx)) fill = MB_HIGHLIGHT
+      else if (cell === 1) fill = MB_BLACK
+      else if (cell === 2) fill = MB_WHITE
+      else fill = MB_EMPTY
+
+      const points: string[] = []
+      for (let i = 0; i < 6; i++) {
+        const [vx, vy] = vtx(px, py, r, i)
+        points.push(`${fmt(vx)},${fmt(vy)}`)
+      }
+      parts.push(
+        `<polygon points="${points.join(' ')}" fill="${fill}" stroke="${MB_OUTLINE}" stroke-width="${fmt(Math.max(0.5, cellSize * 0.08))}"/>`,
+      )
+    }
+  }
+
+  const lw = fmt(Math.max(1.5, cellSize * 0.25))
+
+  // North border (row 0) — Black
+  for (let col = 0; col < cols; col++) {
+    const [hx, hy] = hexCenter(0, col, cellSize)
+    const px = hx + ox, py = hy + oy
+    const [x5, y5] = vtx(px, py, r, 5)
+    const [x0, y0] = vtx(px, py, r, 0)
+    const [x1, y1] = vtx(px, py, r, 1)
+    parts.push(
+      `<polyline points="${fmt(x5)},${fmt(y5)} ${fmt(x0)},${fmt(y0)} ${fmt(x1)},${fmt(y1)}" fill="none" stroke="${MB_EDGE_BLACK}" stroke-width="${lw}"/>`,
+    )
+  }
+
+  // South border (last row) — Black
+  for (let col = 0; col < cols; col++) {
+    const [hx, hy] = hexCenter(rows - 1, col, cellSize)
+    const px = hx + ox, py = hy + oy
+    const [x2, y2] = vtx(px, py, r, 2)
+    const [x3, y3] = vtx(px, py, r, 3)
+    const [x4, y4] = vtx(px, py, r, 4)
+    parts.push(
+      `<polyline points="${fmt(x2)},${fmt(y2)} ${fmt(x3)},${fmt(y3)} ${fmt(x4)},${fmt(y4)}" fill="none" stroke="${MB_EDGE_BLACK}" stroke-width="${lw}"/>`,
+    )
+  }
+
+  // West border (col 0) — White
+  for (let row = 0; row < rows; row++) {
+    const [hx, hy] = hexCenter(row, 0, cellSize)
+    const px = hx + ox, py = hy + oy
+    const [x5, y5] = vtx(px, py, r, 5)
+    const [x4, y4] = vtx(px, py, r, 4)
+    parts.push(
+      `<line x1="${fmt(x5)}" y1="${fmt(y5)}" x2="${fmt(x4)}" y2="${fmt(y4)}" stroke="${MB_EDGE_WHITE}" stroke-width="${lw}"/>`,
+    )
+  }
+
+  // East border (last col) — White
+  for (let row = 0; row < rows; row++) {
+    const [hx, hy] = hexCenter(row, cols - 1, cellSize)
+    const px = hx + ox, py = hy + oy
+    const [x1, y1] = vtx(px, py, r, 1)
+    const [x2, y2] = vtx(px, py, r, 2)
+    parts.push(
+      `<line x1="${fmt(x1)}" y1="${fmt(y1)}" x2="${fmt(x2)}" y2="${fmt(y2)}" stroke="${MB_EDGE_WHITE}" stroke-width="${lw}"/>`,
+    )
+  }
+
+  return parts.join('\n')
+}
+
+// ── SVG export ──────────────────────────────────────────────────────────────
+
+export function exportTreeSvg(
+  root: TreeNode,
+  rows: number,
+  cols: number,
+  layout: LayoutConfig,
+): string {
+  const nodes = collectVisibleNodes(root)
+  const edges = collectVisibleEdges(root)
+  const { nodeWidth, nodeHeight } = layout
+
+  // Compute hex cell size (same logic as TreeRenderer)
+  const maxDim = Math.max(rows, cols)
+  const cellSize = Math.max(4, Math.min(8, Math.floor((nodeWidth - 8 * 2) / (maxDim * 1.8))))
+
+  // Compute bounding box from laid-out nodes
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+  for (const node of nodes) {
+    const nx = node.x - nodeWidth / 2
+    minX = Math.min(minX, nx)
+    minY = Math.min(minY, node.y)
+    maxX = Math.max(maxX, nx + nodeWidth)
+    // Account for collapse badge below node
+    const bottomExtra = (node.collapsed && node.children.length > 0) ? 24 : 0
+    maxY = Math.max(maxY, node.y + nodeHeight + bottomExtra)
+  }
+
+  const pad = 40
+  const svgW = maxX - minX + pad * 2
+  const svgH = maxY - minY + pad * 2
+  const offX = -minX + pad
+  const offY = -minY + pad
+
+  const parts: string[] = []
+
+  // SVG header
+  parts.push(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${fmt(svgW)} ${fmt(svgH)}" width="${fmt(svgW)}" height="${fmt(svgH)}">`,
+  )
+
+  // Embedded style
+  parts.push(`<style>
+  text { font-family: ${FONT}; }
+  .edge-label { font-size: ${EDGE_LABEL_FONT_SIZE}px; }
+  .terminal-badge { font-size: 8px; font-weight: bold; fill: #fff; }
+  .collapse-badge { font-size: 10px; font-weight: bold; fill: ${TEXT}; }
+</style>`)
+
+  // Background
+  parts.push(`<rect width="100%" height="100%" fill="${CREAM}"/>`)
+
+  // Offset group
+  parts.push(`<g transform="translate(${fmt(offX)},${fmt(offY)})">`)
+
+  // ── Edges ──
+  parts.push('<g class="edges">')
+  for (const { parent, edge } of edges) {
+    const x0 = parent.x
+    const y0 = parent.y + nodeHeight
+    const x1 = edge.child.x
+    const y1 = edge.child.y
+    const cpY = (y0 + y1) / 2
+
+    const stroke = edge.isCollision ? COLLISION_COLOR : TEXT_MUTED
+    const dash = edge.isCollision ? ' stroke-dasharray="4,3"' : ''
+
+    parts.push(
+      `<path d="M ${fmt(x0)} ${fmt(y0)} C ${fmt(x0)} ${fmt(cpY)}, ${fmt(x1)} ${fmt(cpY)}, ${fmt(x1)} ${fmt(y1)}" fill="none" stroke="${stroke}" stroke-width="1.5"${dash}/>`,
+    )
+
+    // Edge label at midpoint
+    const mx = (x0 + x1) / 2
+    const my = (y0 + y1) / 2
+    const label = edge.isCollision
+      ? `${edge.label}(c)`
+      : `${edge.label}: ${edge.probability.toFixed(2)}`
+
+    // Approximate text width (rough: 6.5px per char at 11px font)
+    const tw = label.length * 6.5
+    const pillW = tw + 8
+    const pillH = 16
+
+    parts.push(
+      `<rect x="${fmt(mx - pillW / 2)}" y="${fmt(my - pillH / 2)}" width="${fmt(pillW)}" height="${fmt(pillH)}" rx="4" fill="#fff" opacity="0.85"/>`,
+    )
+    parts.push(
+      `<text x="${fmt(mx)}" y="${fmt(my)}" text-anchor="middle" dominant-baseline="central" class="edge-label" fill="${edge.isCollision ? COLLISION_COLOR : TEXT}">${escapeXml(label)}</text>`,
+    )
+  }
+  parts.push('</g>')
+
+  // ── Nodes ──
+  parts.push('<g class="nodes">')
+  for (const node of nodes) {
+    const x = node.x - nodeWidth / 2
+    const y = node.y
+
+    // Node background
+    parts.push(
+      `<rect x="${fmt(x)}" y="${fmt(y)}" width="${nodeWidth}" height="${nodeHeight}" rx="${NODE_RADIUS}" fill="#fff" stroke="${MAUVE_LIGHT}" stroke-width="1.5"/>`,
+    )
+
+    // Mini board
+    parts.push(
+      `<g>`,
+      svgMiniBoard(
+        node.x,
+        y + nodeHeight / 2,
+        node.boardView,
+        rows,
+        cols,
+        cellSize,
+        node.actions.length > 0 ? node.actions.map(([a]) => a) : undefined,
+      ),
+      `</g>`,
+    )
+
+    // Terminal badge
+    if (node.isTerminal) {
+      const badgeW = 28
+      const badgeH = 12
+      const bx = x + nodeWidth - badgeW - 3
+      const by = y + 3
+      parts.push(
+        `<rect x="${fmt(bx)}" y="${fmt(by)}" width="${badgeW}" height="${badgeH}" rx="3" fill="${MAUVE_DARK}"/>`,
+        `<text x="${fmt(bx + badgeW / 2)}" y="${fmt(by + badgeH / 2)}" text-anchor="middle" dominant-baseline="central" class="terminal-badge">END</text>`,
+      )
+    }
+
+    // Collapse badge
+    if (node.collapsed && node.children.length > 0) {
+      const label = `+${node.subtreeSize}`
+      const tw = label.length * 7
+      const badgeW = tw + 8
+      const badgeH = 16
+      const bx = node.x - badgeW / 2
+      const by = y + nodeHeight + 4
+      parts.push(
+        `<rect x="${fmt(bx)}" y="${fmt(by)}" width="${fmt(badgeW)}" height="${badgeH}" rx="4" fill="${MAUVE_LIGHT}" stroke="${MAUVE_DARK}" stroke-width="1"/>`,
+        `<text x="${fmt(node.x)}" y="${fmt(by + badgeH / 2)}" text-anchor="middle" dominant-baseline="central" class="collapse-badge">${escapeXml(label)}</text>`,
+      )
+    }
+  }
+  parts.push('</g>')
+
+  // Close offset group and SVG
+  parts.push('</g>')
+  parts.push('</svg>')
+
+  return parts.join('\n')
+}
+
+// ── Download helper ─────────────────────────────────────────────────────────
+
+export function downloadSvg(svgString: string, filename: string): void {
+  const blob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
+
+// ── Utility ─────────────────────────────────────────────────────────────────
+
+function escapeXml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}

--- a/game/src/investigation/TreeBuilder.ts
+++ b/game/src/investigation/TreeBuilder.ts
@@ -44,6 +44,8 @@ export function buildTree(
     const isTerminal = infoOps.isTerminal(infoState)
     const actions = policy.get(infoState) ?? []
 
+    const isMissing = !isTerminal && actions.length === 0
+
     const node: TreeNode = {
       id,
       infoState,
@@ -52,6 +54,7 @@ export function buildTree(
       children: [],
       depth,
       isTerminal,
+      isMissing,
       x: 0,
       y: 0,
       collapsed: depth >= DEFAULT_COLLAPSE_DEPTH,

--- a/game/src/investigation/TreeLayout.ts
+++ b/game/src/investigation/TreeLayout.ts
@@ -23,6 +23,11 @@ export const DEFAULT_LAYOUT: LayoutConfig = {
  * - Y = depth * (nodeHeight + levelGap)
  *
  * Collapsed nodes are treated as leaves (their children are not laid out).
+ *
+ * DAG-safe: shared nodes (transpositions) are visited only once.
+ * The first path to reach a shared node determines its position;
+ * subsequent edges still render correctly by pointing to that position.
+ *
  * Returns the total bounding box size.
  */
 export function layoutTree(root: TreeNode, config: LayoutConfig): { width: number; height: number } {
@@ -31,7 +36,14 @@ export function layoutTree(root: TreeNode, config: LayoutConfig): { width: numbe
   // Phase 1: compute subtree widths (post-order)
   const widthOf = new Map<number, number>() // node.id → total subtree width
 
-  function computeWidth(node: TreeNode): number {
+  function computeWidth(node: TreeNode, visited: Set<number>): number {
+    // DAG guard: if already visited via another parent, treat as leaf
+    if (visited.has(node.id)) {
+      if (!widthOf.has(node.id)) widthOf.set(node.id, nodeWidth)
+      return widthOf.get(node.id)!
+    }
+    visited.add(node.id)
+
     const visibleChildren = getVisibleChildren(node)
     if (visibleChildren.length === 0) {
       widthOf.set(node.id, nodeWidth)
@@ -41,7 +53,7 @@ export function layoutTree(root: TreeNode, config: LayoutConfig): { width: numbe
     let total = 0
     for (let i = 0; i < visibleChildren.length; i++) {
       if (i > 0) total += siblingGap
-      total += computeWidth(visibleChildren[i])
+      total += computeWidth(visibleChildren[i], visited)
     }
     // Ensure parent is at least nodeWidth wide
     const w = Math.max(total, nodeWidth)
@@ -49,13 +61,17 @@ export function layoutTree(root: TreeNode, config: LayoutConfig): { width: numbe
     return w
   }
 
-  computeWidth(root)
+  computeWidth(root, new Set())
 
   // Phase 2: assign positions (pre-order)
   let maxX = 0
   let maxDepth = 0
 
-  function assignPositions(node: TreeNode, leftX: number): void {
+  function assignPositions(node: TreeNode, leftX: number, visited: Set<number>): void {
+    // DAG guard: skip if already positioned
+    if (visited.has(node.id)) return
+    visited.add(node.id)
+
     const w = widthOf.get(node.id)!
     node.x = leftX + w / 2
     node.y = node.depth * (nodeHeight + levelGap)
@@ -79,12 +95,12 @@ export function layoutTree(root: TreeNode, config: LayoutConfig): { width: numbe
 
     for (let i = 0; i < visibleChildren.length; i++) {
       const cw = widthOf.get(visibleChildren[i].id)!
-      assignPositions(visibleChildren[i], childX)
+      assignPositions(visibleChildren[i], childX, visited)
       childX += cw + siblingGap
     }
   }
 
-  assignPositions(root, 0)
+  assignPositions(root, 0, new Set())
 
   return {
     width: maxX + nodeWidth / 2,
@@ -100,11 +116,14 @@ function getVisibleChildren(node: TreeNode): TreeNode[] {
 
 /**
  * Collect all visible nodes (for rendering).
- * A node is visible if it is the root or its parent is not collapsed.
+ * DAG-safe: each node appears at most once in the result.
  */
 export function collectVisibleNodes(root: TreeNode): TreeNode[] {
   const result: TreeNode[] = []
+  const visited = new Set<number>()
   function walk(node: TreeNode): void {
+    if (visited.has(node.id)) return
+    visited.add(node.id)
     result.push(node)
     if (!node.collapsed) {
       for (const edge of node.children) {
@@ -118,11 +137,15 @@ export function collectVisibleNodes(root: TreeNode): TreeNode[] {
 
 /**
  * Collect all visible edges (for rendering).
- * An edge is visible if its parent node is not collapsed.
+ * DAG-safe: each edge from a non-collapsed parent is included,
+ * even if the child node is shared (edges converge to it).
  */
 export function collectVisibleEdges(root: TreeNode): Array<{ parent: TreeNode; edge: import('./types').TreeEdge }> {
   const result: Array<{ parent: TreeNode; edge: import('./types').TreeEdge }> = []
+  const visited = new Set<number>()
   function walk(node: TreeNode): void {
+    if (visited.has(node.id)) return
+    visited.add(node.id)
     if (!node.collapsed) {
       for (const edge of node.children) {
         result.push({ parent: node, edge })
@@ -132,4 +155,39 @@ export function collectVisibleEdges(root: TreeNode): Array<{ parent: TreeNode; e
   }
   walk(root)
   return result
+}
+
+/**
+ * Compute the maximum depth in the tree (for depth slider range).
+ */
+export function computeMaxDepth(root: TreeNode): number {
+  let maxDepth = 0
+  const visited = new Set<number>()
+  function walk(node: TreeNode): void {
+    if (visited.has(node.id)) return
+    visited.add(node.id)
+    maxDepth = Math.max(maxDepth, node.depth)
+    for (const edge of node.children) {
+      walk(edge.child)
+    }
+  }
+  walk(root)
+  return maxDepth
+}
+
+/**
+ * Set collapsed state for all nodes based on a depth threshold.
+ * Nodes at depth >= threshold are collapsed; nodes below are expanded.
+ */
+export function setCollapseDepth(root: TreeNode, threshold: number): void {
+  const visited = new Set<number>()
+  function walk(node: TreeNode): void {
+    if (visited.has(node.id)) return
+    visited.add(node.id)
+    node.collapsed = node.children.length > 0 && node.depth >= threshold
+    for (const edge of node.children) {
+      walk(edge.child)
+    }
+  }
+  walk(root)
 }

--- a/game/src/investigation/TreeRenderer.ts
+++ b/game/src/investigation/TreeRenderer.ts
@@ -48,6 +48,14 @@ export class TreeRenderer {
   private camY = 0
   private camScale = 1
 
+  // Animation
+  private animStartX = 0
+  private animStartY = 0
+  private animTargetX = 0
+  private animTargetY = 0
+  private animStartTime = 0
+  private animDuration = 0
+
   // Interaction state
   private dragging = false
   private dragStartX = 0
@@ -130,13 +138,28 @@ export class TreeRenderer {
     return this.selectedNode
   }
 
-  /** Smoothly pan the camera to center a node in the viewport. */
+  /** Smoothly animate the camera to center a node in the viewport. */
   panToNode(node: TreeNode): void {
     const { nodeHeight } = this.layout
     const targetX = this.cssWidth / 2 - node.x * this.camScale
     const targetY = this.cssHeight / 2 - (node.y + nodeHeight / 2) * this.camScale
-    this.camX = targetX
-    this.camY = targetY
+
+    // Skip animation if distance is tiny
+    const dx = targetX - this.camX
+    const dy = targetY - this.camY
+    if (dx * dx + dy * dy < 4) {
+      this.camX = targetX
+      this.camY = targetY
+      this._dirty = true
+      return
+    }
+
+    this.animStartX = this.camX
+    this.animStartY = this.camY
+    this.animTargetX = targetX
+    this.animTargetY = targetY
+    this.animStartTime = performance.now()
+    this.animDuration = 200 // ms
     this._dirty = true
   }
 
@@ -248,6 +271,25 @@ export class TreeRenderer {
 
   private _animate = (): void => {
     this._rafId = requestAnimationFrame(this._animate)
+
+    // Update camera animation
+    if (this.animDuration > 0) {
+      const now = performance.now()
+      const elapsed = now - this.animStartTime
+      if (elapsed >= this.animDuration) {
+        this.camX = this.animTargetX
+        this.camY = this.animTargetY
+        this.animDuration = 0
+      } else {
+        // Ease-out cubic: 1 - (1-t)^3
+        const t = elapsed / this.animDuration
+        const ease = 1 - (1 - t) * (1 - t) * (1 - t)
+        this.camX = this.animStartX + (this.animTargetX - this.animStartX) * ease
+        this.camY = this.animStartY + (this.animTargetY - this.animStartY) * ease
+      }
+      this._dirty = true
+    }
+
     if (!this._dirty) return
     this._dirty = false
     this._draw()

--- a/game/src/investigation/TreeRenderer.ts
+++ b/game/src/investigation/TreeRenderer.ts
@@ -27,6 +27,13 @@ export interface TreeRendererCallbacks {
   onNodeDoubleClick: (node: TreeNode) => void
 }
 
+/** Navigation info computed from the visible tree structure. */
+interface NavMap {
+  parent: Map<number, TreeNode>            // child.id → parent node
+  siblingIndex: Map<number, number>        // node.id → index in parent's visible children
+  visibleChildren: Map<number, TreeNode[]> // node.id → visible child nodes
+}
+
 export class TreeRenderer {
   private canvas: HTMLCanvasElement
   private ctx: CanvasRenderingContext2D
@@ -56,6 +63,7 @@ export class TreeRenderer {
   private visibleEdges: Array<{ parent: TreeNode; edge: TreeEdge }> = []
   private treeWidth = 0
   private treeHeight = 0
+  private nav: NavMap = { parent: new Map(), siblingIndex: new Map(), visibleChildren: new Map() }
 
   // RAF
   private _rafId = 0
@@ -109,12 +117,102 @@ export class TreeRenderer {
     this.treeHeight = bounds.height
     this.visibleNodes = collectVisibleNodes(this.root)
     this.visibleEdges = collectVisibleEdges(this.root)
+    this._buildNavMap()
     this._dirty = true
   }
 
   selectNode(node: TreeNode | null): void {
     this.selectedNode = node
     this._dirty = true
+  }
+
+  getSelectedNode(): TreeNode | null {
+    return this.selectedNode
+  }
+
+  /** Smoothly pan the camera to center a node in the viewport. */
+  panToNode(node: TreeNode): void {
+    const { nodeHeight } = this.layout
+    const targetX = this.cssWidth / 2 - node.x * this.camScale
+    const targetY = this.cssHeight / 2 - (node.y + nodeHeight / 2) * this.camScale
+    this.camX = targetX
+    this.camY = targetY
+    this._dirty = true
+  }
+
+  /**
+   * Handle arrow-key navigation. Returns the newly focused node, or null.
+   * - ArrowUp: parent
+   * - ArrowDown: first visible child (expands if collapsed)
+   * - ArrowLeft: previous sibling
+   * - ArrowRight: next sibling
+   */
+  navigateKey(key: string, current: TreeNode | null): TreeNode | null {
+    if (!current) {
+      // No selection — start at root
+      return this.root
+    }
+
+    const { parent, siblingIndex, visibleChildren } = this.nav
+
+    switch (key) {
+      case 'ArrowUp': {
+        const p = parent.get(current.id)
+        return p ?? null
+      }
+      case 'ArrowDown': {
+        const children = visibleChildren.get(current.id)
+        if (children && children.length > 0) return children[0]
+        return null
+      }
+      case 'ArrowLeft': {
+        const p = parent.get(current.id)
+        if (!p) return null
+        const siblings = visibleChildren.get(p.id)
+        if (!siblings) return null
+        const idx = siblingIndex.get(current.id) ?? 0
+        return idx > 0 ? siblings[idx - 1] : null
+      }
+      case 'ArrowRight': {
+        const p = parent.get(current.id)
+        if (!p) return null
+        const siblings = visibleChildren.get(p.id)
+        if (!siblings) return null
+        const idx = siblingIndex.get(current.id) ?? 0
+        return idx < siblings.length - 1 ? siblings[idx + 1] : null
+      }
+      default:
+        return null
+    }
+  }
+
+  /** Build parent/sibling lookup from visible nodes. */
+  private _buildNavMap(): void {
+    const parent = new Map<number, TreeNode>()
+    const siblingIndex = new Map<number, number>()
+    const vc = new Map<number, TreeNode[]>()
+    const visited = new Set<number>()
+
+    const walk = (node: TreeNode): void => {
+      if (visited.has(node.id)) return
+      visited.add(node.id)
+
+      if (!node.collapsed) {
+        const children = node.children.map((e) => e.child)
+        vc.set(node.id, children)
+        children.forEach((child, i) => {
+          if (!parent.has(child.id)) {
+            parent.set(child.id, node)
+            siblingIndex.set(child.id, i)
+          }
+        })
+        for (const child of children) walk(child)
+      } else {
+        vc.set(node.id, [])
+      }
+    }
+    walk(this.root)
+    this.nav = { parent, siblingIndex, visibleChildren: vc }
   }
 
   fitToView(): void {
@@ -129,6 +227,11 @@ export class TreeRenderer {
     this.camX = (cw - this.treeWidth * this.camScale) / 2
     this.camY = (ch - this.treeHeight * this.camScale) / 2 + pad / 2
     this._dirty = true
+  }
+
+  /** Recalculate canvas backing store after container resize. */
+  resize(): void {
+    this._resizeCanvas()
   }
 
   dispose(): void {

--- a/game/src/investigation/TreeRenderer.ts
+++ b/game/src/investigation/TreeRenderer.ts
@@ -368,6 +368,23 @@ export class TreeRenderer {
       ctx.fillText('END', bx + badgeW / 2, by + badgeH / 2)
     }
 
+    // Missing policy badge (non-terminal but no policy entry)
+    if (node.isMissing) {
+      const badgeW = 12
+      const badgeH = 12
+      const bx = x + nodeWidth - badgeW - 3
+      const by = y + 3
+      ctx.beginPath()
+      this._roundRect(ctx, bx, by, badgeW, badgeH, 3)
+      ctx.fillStyle = '#d4920a'
+      ctx.fill()
+      ctx.fillStyle = '#fff'
+      ctx.font = `bold 9px ${FONT}`
+      ctx.textAlign = 'center'
+      ctx.textBaseline = 'middle'
+      ctx.fillText('?', bx + badgeW / 2, by + badgeH / 2)
+    }
+
     // Collapse badge: show "+N" if collapsed and has children
     if (node.collapsed && node.children.length > 0) {
       const label = `+${node.subtreeSize}`

--- a/game/src/investigation/policyImport.ts
+++ b/game/src/investigation/policyImport.ts
@@ -51,8 +51,10 @@ export function loadPolicyFromFile(): Promise<{ config: StrategyConfig; policy: 
     document.body.appendChild(input)
 
     let resolved = false
+    let fileChosen = false
 
     input.addEventListener('change', () => {
+      fileChosen = true
       const file = input.files?.[0]
       input.remove()
       if (!file) { resolved = true; resolve(null); return }
@@ -77,7 +79,7 @@ export function loadPolicyFromFile(): Promise<{ config: StrategyConfig; policy: 
     // Focus returns to window after picker closes
     window.addEventListener('focus', () => {
       setTimeout(() => {
-        if (!resolved) {
+        if (!resolved && !fileChosen) {
           input.remove()
           resolved = true
           resolve(null)

--- a/game/src/investigation/policyImport.ts
+++ b/game/src/investigation/policyImport.ts
@@ -10,6 +10,12 @@ export function parseExportedPolicy(data: unknown): { config: StrategyConfig; po
   if (typeof obj.policy !== 'object' || obj.policy === null) throw new Error('Invalid policy: missing policy map')
 
   const exported = obj as unknown as ExportedPolicy
+
+  // Strict range validation
+  if (exported.player !== 0 && exported.player !== 1) throw new Error(`Invalid player: ${exported.player} (must be 0 or 1)`)
+  if (!Number.isInteger(exported.rows) || exported.rows < 1 || exported.rows > 19) throw new Error(`Invalid rows: ${exported.rows}`)
+  if (!Number.isInteger(exported.cols) || exported.cols < 1 || exported.cols > 19) throw new Error(`Invalid cols: ${exported.cols}`)
+
   const config: StrategyConfig = {
     player: exported.player,
     rows: exported.rows,

--- a/game/src/investigation/types.ts
+++ b/game/src/investigation/types.ts
@@ -8,6 +8,8 @@ export interface TreeNode {
   children: TreeEdge[]
   depth: number
   isTerminal: boolean
+  /** True if this non-terminal state has no policy entry (partial checkpoint). */
+  isMissing: boolean
   // Layout (set by TreeLayout)
   x: number
   y: number

--- a/game/src/scenes/BoardScene.ts
+++ b/game/src/scenes/BoardScene.ts
@@ -361,6 +361,7 @@ export class BoardScene {
         }
 
         case 'strategy-investigation': {
+          const token = this._sessionToken
           const loaded = await loadPolicyFromFile()
           if (!loaded) {
             // Cancelled file picker — loop back to menu
@@ -369,7 +370,13 @@ export class BoardScene {
             this.controls.autoRotateSpeed = 0.3
             continue
           }
-          await this._runInvestigation(loaded.policy, loaded.config)
+          if (token !== this._sessionToken) return // session cancelled while picking file
+          try {
+            await this._runInvestigation(loaded.policy, loaded.config)
+          } catch (err) {
+            console.error('Investigation failed:', err)
+            // Bad policy file — fall through to menu
+          }
           // Return to menu after investigation exits
           this._menuOpen = true
           this.controls.autoRotate = true

--- a/scripts/export_policy.py
+++ b/scripts/export_policy.py
@@ -14,6 +14,21 @@ import sys
 from darkhex._engine import MCCFRSolver, simplify_policy, simplify_policy_plus
 
 
+def rotate_info_state(info_state: str, rows: int, cols: int) -> str:
+    """Compute the 180° rotated info state string."""
+    lines = info_state.split("\n")
+    player_line = lines[0]
+    board = "".join(lines[1:])
+    rotated = board[::-1]
+    board_lines = [rotated[i : i + cols] for i in range(0, len(rotated), cols)]
+    return player_line + "\n" + "\n".join(board_lines)
+
+
+def rotate_action(action: int, total_cells: int) -> int:
+    """Rotate a cell index by 180°."""
+    return total_cells - 1 - action
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Convert MCCFR checkpoint to DSaGe policy JSON",
@@ -79,12 +94,27 @@ def main() -> None:
     )
 
     # Convert to ExportedPolicy format: {info_state: {action_str: prob}}
+    # The solver stores canonical keys (isomorphic reduction via 180° rotation).
+    # The tree builder generates raw keys. Emit both canonical and rotated forms
+    # so lookups succeed regardless of which form the tree builder produces.
+    rows, cols = solver.rows(), solver.cols()
+    total_cells = rows * cols
     policy_dict: dict[str, dict[str, float]] = {}
     for info_state, actions in player_strategy.items():
         action_map: dict[str, float] = {}
         for action, prob in actions:
             action_map[str(action)] = round(float(prob), 6)
         policy_dict[info_state] = action_map
+
+        # Also emit the rotated (non-canonical) form
+        rotated_key = rotate_info_state(info_state, rows, cols)
+        if rotated_key != info_state and rotated_key not in policy_dict:
+            rotated_actions: dict[str, float] = {}
+            for action, prob in actions:
+                rotated_actions[str(rotate_action(action, total_cells))] = round(
+                    float(prob), 6,
+                )
+            policy_dict[rotated_key] = rotated_actions
 
     output = {
         "player": args.player,

--- a/scripts/export_policy.py
+++ b/scripts/export_policy.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Convert MCCFR solver checkpoint (.bin) to DSaGe policy JSON.
+
+Usage:
+    python scripts/export_policy.py checkpoint.bin --player 0 -o policy.json
+    python scripts/export_policy.py checkpoint.bin --player 0 --sip 0.05 2
+    python scripts/export_policy.py checkpoint.bin --player 0 --sip-plus 0.05 2 8 0.01
+"""
+
+import argparse
+import json
+import sys
+
+from darkhex._engine import MCCFRSolver, simplify_policy, simplify_policy_plus
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert MCCFR checkpoint to DSaGe policy JSON",
+    )
+    parser.add_argument("checkpoint", help="Path to .bin checkpoint file")
+    parser.add_argument(
+        "--player", "-p", type=int, required=True, choices=[0, 1],
+        help="Player to extract (0=Black, 1=White)",
+    )
+    parser.add_argument(
+        "--output", "-o", default=None,
+        help="Output JSON path (default: stdout)",
+    )
+    parser.add_argument(
+        "--sip", nargs=2, type=float, metavar=("EPSILON", "ACTION_CAP"),
+        help="Apply SIP simplification (epsilon, action_cap)",
+    )
+    parser.add_argument(
+        "--sip-plus", nargs=4, type=float,
+        metavar=("EPSILON", "ACTION_CAP", "FRAC_LIMIT", "ETA"),
+        help="Apply SIP+ simplification (epsilon, action_cap, frac_limit, eta)",
+    )
+
+    args = parser.parse_args()
+
+    # Load checkpoint
+    solver = MCCFRSolver.load(args.checkpoint)
+    print(
+        f"Loaded: {solver.rows()}x{solver.cols()}, "
+        f"{solver.iterations()} iters, "
+        f"{solver.num_info_states()} info states",
+        file=sys.stderr,
+    )
+
+    # Extract average strategy
+    strategy = solver.get_average_strategy()
+
+    # Optional simplification
+    if args.sip:
+        epsilon, action_cap = args.sip
+        strategy = simplify_policy(strategy, epsilon, int(action_cap))
+        print(f"SIP: eps={epsilon}, cap={int(action_cap)}", file=sys.stderr)
+    elif args.sip_plus:
+        epsilon, action_cap, frac_limit, eta = args.sip_plus
+        strategy = simplify_policy_plus(
+            strategy, epsilon, int(action_cap), int(frac_limit), eta,
+        )
+        print(
+            f"SIP+: eps={epsilon}, cap={int(action_cap)}, "
+            f"frac={int(frac_limit)}, eta={eta}",
+            file=sys.stderr,
+        )
+
+    # Filter by player
+    prefix = f"P{args.player}\n"
+    player_strategy = {
+        k: v for k, v in strategy.items() if k.startswith(prefix)
+    }
+    print(
+        f"Player {args.player}: {len(player_strategy)} info states "
+        f"(of {len(strategy)} total)",
+        file=sys.stderr,
+    )
+
+    # Convert to ExportedPolicy format: {info_state: {action_str: prob}}
+    policy_dict: dict[str, dict[str, float]] = {}
+    for info_state, actions in player_strategy.items():
+        action_map: dict[str, float] = {}
+        for action, prob in actions:
+            action_map[str(action)] = round(float(prob), 6)
+        policy_dict[info_state] = action_map
+
+    output = {
+        "player": args.player,
+        "rows": solver.rows(),
+        "cols": solver.cols(),
+        "perfectRecall": False,
+        "policy": policy_dict,
+    }
+
+    json_str = json.dumps(output, ensure_ascii=False, indent=2)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(json_str)
+            f.write("\n")
+        print(f"Written to {args.output}", file=sys.stderr)
+    else:
+        print(json_str)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **SVG export**: "Export SVG" button in investigation screen produces publication-quality vector diagrams of strategy trees with hex boards, bezier edges, collision dashes, and badges
- **MCCFR policy loading**: `scripts/export_policy.py` CLI converts solver checkpoint `.bin` files to JSON matching the web app's import format, with optional `--sip` / `--sip-plus` simplification
- **Depth slider + collapse controls**: default to depth 1 (manageable view), slider to control visible depth, Expand All / Collapse All buttons
- **Keyboard navigation**: arrow keys for parent/child/sibling traversal, Enter/Space to toggle collapse, camera auto-pans to focused node
- **Bug fixes**: DAG transposition (visited sets in TreeLayout), policy import race condition (fileChosen flag), sidebar canvas resize

## Test plan

- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Game builds (`npx vite build`)
- [x] Rust tests pass (109 core, 11 MCCFR)
- [x] Python tests pass (148 passed)
- [x] `export_policy.py` tested with 2x2 checkpoint (plain, SIP, SIP+)
- [x] Visual verification: investigation screen loads 3x3 MCCFR policy, depth slider works, SVG export matches canvas
- [x] Codex adversarial review findings addressed (DAG transposition, import race)
- [ ] Test keyboard navigation with various policy sizes
- [ ] Test SVG export of large trees (3x3+) in Inkscape/LaTeX